### PR TITLE
fix: correct Grow Daisy canonical URLs from godaisy.io to grow.godaisy.io

### DIFF
--- a/pages/grow/activities/index.tsx
+++ b/pages/grow/activities/index.tsx
@@ -12,7 +12,7 @@ export default function GrowActivitiesPage() {
           name="description"
           content="Track and manage your garden activities, tasks, and accomplishments."
         />
-        <link rel="canonical" href="https://godaisy.io/grow/activities" />
+        <link rel="canonical" href="https://grow.godaisy.io/grow/activities" />
       </Head>
       <main className="container mx-auto px-4 py-8">
         <ActivitiesPage userInterests={null} />

--- a/pages/grow/garden/index.tsx
+++ b/pages/grow/garden/index.tsx
@@ -18,14 +18,14 @@ export default function GrowGardenPage() {
         <meta property="og:title" content="My Garden - Grow Daisy" />
         <meta property="og:description" content="Manage your garden plants and get personalized care recommendations." />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://godaisy.io/grow/garden" />
+        <meta property="og:url" content="https://grow.godaisy.io/grow/garden" />
 
         {/* Twitter Card */}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content="My Garden - Grow Daisy" />
         <meta name="twitter:description" content="Manage your garden plants and get personalized care recommendations." />
 
-        <link rel="canonical" href="https://godaisy.io/grow/garden" />
+        <link rel="canonical" href="https://grow.godaisy.io/grow/garden" />
       </Head>
       <main className="container mx-auto px-4 py-8">
         <GardenPage />

--- a/pages/grow/index.tsx
+++ b/pages/grow/index.tsx
@@ -17,16 +17,16 @@ export default function GrowPage() {
         <meta property="og:title" content="Grow Daisy - Smart Garden Planning" />
         <meta property="og:description" content="Plan your garden with weather-based task recommendations and personalized planting calendars." />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://godaisy.io/grow" />
-        <meta property="og:image" content="https://godaisy.io/og-grow.png" />
+        <meta property="og:url" content="https://grow.godaisy.io/grow" />
+        <meta property="og:image" content="https://grow.godaisy.io/og-grow.png" />
 
         {/* Twitter Card */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Grow Daisy - Smart Garden Planning" />
         <meta name="twitter:description" content="Plan your garden with weather-based task recommendations and personalized planting calendars." />
-        <meta name="twitter:image" content="https://godaisy.io/og-grow.png" />
+        <meta name="twitter:image" content="https://grow.godaisy.io/og-grow.png" />
 
-        <link rel="canonical" href="https://godaisy.io/grow" />
+        <link rel="canonical" href="https://grow.godaisy.io/grow" />
       </Head>
       <GrowExperience />
     </>

--- a/pages/grow/plan/index.tsx
+++ b/pages/grow/plan/index.tsx
@@ -18,14 +18,14 @@ export default function GrowPlanPage() {
         <meta property="og:title" content="Garden Planning Calendar - Grow Daisy" />
         <meta property="og:description" content="View your personalized planting calendar and seasonal garden timeline." />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://godaisy.io/grow/plan" />
+        <meta property="og:url" content="https://grow.godaisy.io/grow/plan" />
 
         {/* Twitter Card */}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content="Garden Planning Calendar - Grow Daisy" />
         <meta name="twitter:description" content="View your personalized planting calendar and seasonal garden timeline." />
 
-        <link rel="canonical" href="https://godaisy.io/grow/plan" />
+        <link rel="canonical" href="https://grow.godaisy.io/grow/plan" />
       </Head>
       <main className="container mx-auto px-4 py-8">
         <PlanPage />

--- a/pages/grow/species/[slug].tsx
+++ b/pages/grow/species/[slug].tsx
@@ -812,7 +812,7 @@ export default function GrowSpeciesPage() {
         {species?.slug ? (
           <link
             rel="canonical"
-            href={`https://godaisy.io/grow/species/${species.slug}`}
+            href={`https://grow.godaisy.io/grow/species/${species.slug}`}
           />
         ) : null}
         <meta property="og:title" content={title} />

--- a/pages/grow/weather/index.tsx
+++ b/pages/grow/weather/index.tsx
@@ -18,14 +18,14 @@ export default function GrowWeatherPage() {
         <meta property="og:title" content="Garden Weather Conditions - Grow Daisy" />
         <meta property="og:description" content="Track weather conditions and optimal gardening windows for your location." />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://godaisy.io/grow/weather" />
+        <meta property="og:url" content="https://grow.godaisy.io/grow/weather" />
 
         {/* Twitter Card */}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content="Garden Weather Conditions - Grow Daisy" />
         <meta name="twitter:description" content="Track weather conditions and optimal gardening windows for your location." />
 
-        <link rel="canonical" href="https://godaisy.io/grow/weather" />
+        <link rel="canonical" href="https://grow.godaisy.io/grow/weather" />
       </Head>
       <main className="container mx-auto px-4 py-8">
         <WeatherPage />


### PR DESCRIPTION
## Summary

Audit of all Grow Daisy pages found 6 files with \`<link rel="canonical">\`, \`og:url\`, and \`og:image\` meta tags hardcoded to \`godaisy.io\` instead of the correct \`grow.godaisy.io\` subdomain.

**Files fixed:**
- \`pages/grow/index.tsx\` — canonical, og:url, og:image, twitter:image
- \`pages/grow/garden/index.tsx\` — canonical, og:url
- \`pages/grow/activities/index.tsx\` — canonical
- \`pages/grow/plan/index.tsx\` — canonical, og:url
- \`pages/grow/weather/index.tsx\` — canonical, og:url
- \`pages/grow/species/[slug].tsx\` — canonical

**Not changed:** email addresses (\`hello@godaisy.io\`, \`privacy@godaisy.io\`) and the support page link to the Go Daisy homepage — these are correct as-is.

## Test plan
- [ ] Verify canonical tags render correctly in page source at \`grow.godaisy.io/grow\`, \`/grow/garden\`, \`/grow/plan\`, \`/grow/weather\`, \`/grow/activities\`, and a species page
- [ ] Confirm no remaining \`https://godaisy.io\` in canonical/og meta tags under \`pages/grow/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)