### PR TITLE
ci: inject Supabase env vars into build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Type check
         run: npm run build --silent
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Summary
- Adds `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` as referenced secrets in the build workflow step
- Fixes the pre-existing `@supabase/ssr` error during Next.js static page collection in CI
- Both values are already public (bundled into client JS); adding them as secrets is safe

## Test plan
- [ ] Verify Build check passes on next PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)