### PR TITLE
feat(seo): landing page redesign + programmatic activity/location pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ android/*.keystore
 
 # Temporary preview files
 glossary-preview.html
+
+# Backup files
+*.bak-grow

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -24,7 +24,6 @@
 
 import React from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import Head from 'next/head';
 import AppHeader from './AppHeader';
 import dynamic from 'next/dynamic';

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,0 +1,798 @@
+/**
+ * Go Daisy — public marketing landing page.
+ *
+ * Rendered server-side at `/` for non-authenticated web visitors so that
+ * search engines and first-time visitors get rich, indexable content
+ * instead of the app skeleton. Capacitor (native iOS/Android) and
+ * logged-in users continue to see the app dashboard as before.
+ *
+ * Conditional rendering happens in `pages/index.tsx` via getServerSideProps.
+ *
+ * Single-file by design: easier for a non-developer maintainer to find,
+ * read and edit every section without hunting through nested components.
+ *
+ * Sections in order:
+ *   1. Hero
+ *   2. How it works (3 steps)
+ *   3. Activities (the SEO engine — every activity name in plain text)
+ *   4. What we read (data sources)
+ *   5. Top FAQs (with FAQPage JSON-LD inline)
+ *   6. Android tester recruitment
+ *   7. Final CTA
+ *   8. SoftwareApplication JSON-LD (in the same Head as the FAQ JSON-LD)
+ */
+
+import React from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import Head from 'next/head';
+import AppHeader from './AppHeader';
+import dynamic from 'next/dynamic';
+import SEO from './SEO';
+
+const Footer = dynamic(() => import('./footer'), { ssr: false });
+
+// App Store URL — update if you change territories
+const APP_STORE_URL =
+  'https://apps.apple.com/gb/app/go-daisy/id6755695873';
+
+// Where the primary CTA sends visitors who want to try the web app.
+// `/login` shows the sign-up / sign-in screen.
+const WEB_APP_CTA_URL = '/login';
+
+// ============================================================================
+// FAQ data — keep questions phrased exactly as people search for them.
+// Update the question/answer text here and the JSON-LD updates automatically.
+// ============================================================================
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+const TOP_FAQS: FaqItem[] = [
+  {
+    q: 'What does Go Daisy do?',
+    a: "Go Daisy is a free weather app organised around the things you want to do, not the weather itself. You tell it which activities you care about — from surfing and hiking to padel, cricket and Sunday pub afternoons — and it reads the forecast to tell you when conditions are right for each one. Less '70% chance of rain at 3pm', more 'great evening for a swim, terrible morning for the bike, classic museum afternoon.'",
+  },
+  {
+    q: 'How many activities does Go Daisy cover?',
+    a: 'Over 100, organised into six worlds: active sports (team, individual, water, action), fitness and wellness, outdoor activities (nature, fishing, kicking back), winter sports, creative and arts, and indoor recreation. You only see the ones you tell us you care about.',
+  },
+  {
+    q: 'Is Go Daisy free?',
+    a: 'Yes — completely. No paywall, no premium tier, no ads, no in-app purchases. Go Daisy is the part of what we do that is for everyone, supported by our deeper specialist apps for anglers, fly fishers and gardeners.',
+  },
+  {
+    q: 'Does Go Daisy cover water sports?',
+    a: 'Yes — surfing, stand-up paddleboarding (SUP) on sea and inland, kayaking and sea kayaking, canoeing, sea swimming, wild swimming, snorkelling, sailing on sea and inland, windsurfing on sea and inland, kitesurfing, jet skiing, scuba diving and sea fishing from shore or boat. We pull wave height, swell period and direction, wind, sea temperature, tides and UV from Stormglass marine services and score each sport on its own terms.',
+  },
+  {
+    q: 'Does Go Daisy cover padel, pickleball and team sports?',
+    a: 'Yes — and they are scored properly, not lumped under "tennis". Padel and pickleball each have their own scoring; team sports include football, rugby, cricket, basketball, beach volleyball, American football, baseball, hurling, camogie, Gaelic football, hockey, netball and ice hockey. Cricket gets the strictest answer because cricket has the strictest weather.',
+  },
+  {
+    q: 'What about winter sports and indoor activities?',
+    a: 'Yes to both. Winter: skiing (alpine), snowboarding, cross-country skiing, ice skating, curling, ice hockey, ice fishing. Indoor: indoor climbing, indoor tennis, squash, badminton, indoor swimming, gym, pilates, yoga, meditation — plus social and home days like the pub, cinema, museums, galleries, bowling, cooking, reading, gaming, crafts and making music. When the outdoor scores are bad, the indoor activities you have picked get a quiet promotion.',
+  },
+  {
+    q: 'How is Go Daisy different from Windy or the Met Office?',
+    a: 'General weather apps tell you the weather and trust you to interpret it. Go Daisy tells you whether your thing is on. We read the same kinds of data — from OpenWeather, Stormglass and api.met.no — and then apply it to whichever activities you have told us you do, so you do not have to do the mental arithmetic of "is 14 mph from the south-west too much for a paddleboard at my local lake?" every time you open the app.',
+  },
+  {
+    q: 'Is Go Daisy on Android?',
+    a: 'The Android version is built and in closed beta. Google Play asks new apps to put twelve testers through a fortnight of real-world use before launching to the public, and we are recruiting that group now. If you have an Android phone and would like to be one of our twelve, see the Android testers section on this page. The web app at godaisy.io works in any browser, on any phone, in the meantime.',
+  },
+];
+
+// ============================================================================
+// Activity lists by category — full taxonomy from the app.
+// Updating this list also updates the rendered SEO surface area.
+// ============================================================================
+
+interface ActivityCategory {
+  name: string;
+  icon: string;
+  description: string;
+  subCategories: { name: string; activities: string[] }[];
+}
+
+const ACTIVITY_CATEGORIES: ActivityCategory[] = [
+  {
+    name: 'Active sports',
+    icon: '🏃‍♂️',
+    description:
+      'Pitches, courts, water, wheels and walls. Every sport gets its own score because what makes a great day for one is often a wash-out for another.',
+    subCategories: [
+      {
+        name: 'Team sports',
+        activities: [
+          'Football',
+          'Cricket',
+          'Rugby',
+          'Basketball (outdoor)',
+          'Beach volleyball',
+          'American football',
+          'Baseball',
+          'Hurling',
+          'Camogie',
+          'Gaelic football',
+          'Hockey',
+          'Netball',
+          'Ice hockey',
+        ],
+      },
+      {
+        name: 'Individual sports',
+        activities: [
+          'Golf',
+          'Tennis',
+          'Indoor tennis',
+          'Squash',
+          'Badminton',
+          'Table tennis',
+          'Archery',
+          'Pickleball',
+          'Indoor volleyball',
+          'Padel',
+        ],
+      },
+      {
+        name: 'Water sports',
+        activities: [
+          'Surfing',
+          'Stand-up paddleboarding (SUP)',
+          'SUP at sea',
+          'Kayaking',
+          'Sea kayaking',
+          'Canoeing',
+          'Sea swimming',
+          'Indoor swimming',
+          'Snorkelling',
+          'Scuba diving',
+          'Sailing',
+          'Inland sailing',
+          'Windsurfing',
+          'Inland windsurfing',
+          'Kitesurfing',
+          'Jet skiing',
+          'Sea fishing (shore)',
+          'Sea fishing (boat)',
+        ],
+      },
+      {
+        name: 'Action sports',
+        activities: [
+          'Mountain biking',
+          'Road cycling',
+          'Gravel biking',
+          'Rock climbing',
+          'Rock hopping',
+          'Indoor climbing',
+          'Skateboarding',
+          'Rollerblading',
+          'Motorbike riding',
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Fitness & wellness',
+    icon: '💪',
+    description:
+      'For the things you do to feel better. We score the indoor and outdoor versions separately because the conditions that matter are different.',
+    subCategories: [
+      {
+        name: 'Mindfulness',
+        activities: [
+          'Yoga',
+          'Outdoor yoga',
+          'Meditation',
+          'Outdoor meditation',
+          'Pilates',
+          'Martial arts',
+          'Tai chi',
+        ],
+      },
+      {
+        name: 'Cardio & running',
+        activities: [
+          'Running',
+          'Trail running',
+          'Cycling',
+          'Urban exploring',
+        ],
+      },
+      {
+        name: 'Strength & gym',
+        activities: [
+          'Gym workouts',
+          'Outdoor gyms',
+          'Zumba',
+          'Boxing',
+          'Spinning',
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Outdoor activities',
+    icon: '🌲',
+    description:
+      'The big-skies stuff. Nature, fishing and the deceptively important business of doing very little in pleasant weather.',
+    subCategories: [
+      {
+        name: 'Nature',
+        activities: [
+          'Hiking',
+          'Birdwatching',
+          'Photography',
+          'Foraging',
+          'Mushroom hunting',
+          'Wild swimming',
+          'Outdoor gardening',
+          'Stargazing',
+        ],
+      },
+      {
+        name: 'Fishing',
+        activities: [
+          'Fly fishing (freshwater)',
+          'Coarse fishing',
+          'Sea fishing (shore)',
+          'Sea fishing (boat)',
+          'Ice fishing',
+        ],
+      },
+      {
+        name: 'Kicking back & relaxing',
+        activities: [
+          'Picnicking',
+          'Barbecues',
+          'Beach days',
+          'Camping',
+          'Outdoor gardening',
+          'Gaming',
+          'Reading',
+          'Going to the pub',
+          'Outdoor reading',
+          'Dog walking',
+          'Outdoor playground',
+          'Outdoor chess',
+          'Outdoor painting',
+          'Outdoor music',
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Winter sports',
+    icon: '❄️',
+    description:
+      'Snow and ice each have their own complicated relationship with the weather. We watch snow depth, fresh snowfall, wind chill at altitude, freeze-thaw history — and score skiing, snowboarding, cross-country, skating and natural ice separately.',
+    subCategories: [
+      {
+        name: 'Snow sports',
+        activities: ['Skiing (alpine)', 'Snowboarding', 'Cross-country skiing'],
+      },
+      {
+        name: 'Ice sports',
+        activities: [
+          'Ice skating',
+          'Curling',
+          'Ice hockey',
+          'Ice fishing',
+          'Indoor ice hockey',
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Creative & arts',
+    icon: '🎨',
+    description:
+      'For the things that need a particular kind of light, a particular kind of quiet, or a garden that can handle a PA system.',
+    subCategories: [
+      {
+        name: 'Visual arts',
+        activities: [
+          'Painting',
+          'Outdoor painting (plein air)',
+          'Crafts',
+          'Photography',
+          'Knitting',
+          'DIY',
+        ],
+      },
+      {
+        name: 'Music & performance',
+        activities: [
+          'Playing records',
+          'Making music',
+          'Dance',
+          'Outdoor music',
+        ],
+      },
+      {
+        name: 'Literature & learning',
+        activities: ['Reading', 'Outdoor reading'],
+      },
+    ],
+  },
+  {
+    name: 'Indoor recreation',
+    icon: '🏠',
+    description:
+      'For the days the weather has other ideas. When the outdoor scores are bad, your indoor and social activities get a quiet promotion — so a wet Sunday is not a wasted one.',
+    subCategories: [
+      {
+        name: 'Home activities',
+        activities: [
+          'Crafts',
+          'Knitting',
+          'Reading',
+          'DIY',
+          'Playing records',
+          'Cooking',
+          'Painting',
+          'Gaming',
+          'Online time',
+        ],
+      },
+      {
+        name: 'Social activities',
+        activities: [
+          'Going to the pub',
+          'Table tennis',
+          'Playing cards',
+          'Watching a film',
+          'Café days',
+          'Cinema',
+          'Museum',
+          'Shopping',
+          'Dance',
+          'Gallery',
+          'Bowling',
+        ],
+      },
+      {
+        name: 'Indoor sports',
+        activities: [
+          'Indoor climbing',
+          'Squash',
+          'Badminton',
+          'Indoor tennis',
+          'Indoor swimming',
+          'Gym workouts',
+          'Pilates',
+          'Yoga',
+          'Meditation',
+        ],
+      },
+    ],
+  },
+];
+
+// ============================================================================
+// JSON-LD blocks for FAQ rich result + SoftwareApplication
+// ============================================================================
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: TOP_FAQS.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: f.a,
+    },
+  })),
+};
+
+const softwareAppJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'MobileApplication',
+  name: 'Go Daisy',
+  description:
+    'Free weather app for 100+ activities — hiking, surfing, padel, cricket, stargazing, gardening and more. Reads wind, waves, tides, UV, pressure and sky to tell you when each activity is on.',
+  applicationCategory: 'WeatherApplication',
+  operatingSystem: 'iOS',
+  url: 'https://godaisy.io',
+  installUrl: APP_STORE_URL,
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+  featureList: ACTIVITY_CATEGORIES.map((c) => c.name).join(', '),
+  publisher: {
+    '@type': 'Organization',
+    name: 'Go Daisy',
+    url: 'https://godaisy.io',
+  },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+const LandingPage: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title="Free weather app for 100+ activities — hiking, surfing, padel, cricket, yoga"
+        description="Tell Go Daisy what you do — hiking, surfing, padel, cricket, pilates, stargazing, gardening, even pub afternoons — and we read the wind, waves, tides, UV and sky to tell you when each one is on. Free, ad-free. UK and Europe."
+        url="https://godaisy.io"
+        type="website"
+      />
+
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareAppJsonLd) }}
+        />
+      </Head>
+
+      <AppHeader />
+
+      <main className="min-h-screen bg-base-100 text-base-content">
+        {/* =================================================================
+            HERO
+            ================================================================= */}
+        <section className="px-4 py-12 md:py-20 bg-gradient-to-b from-base-200 to-base-100">
+          <div className="max-w-5xl mx-auto text-center">
+            <h1 className="text-4xl md:text-6xl font-bold leading-tight mb-6">
+              Weather-perfect days for the things you actually love.
+            </h1>
+            <p className="text-lg md:text-2xl text-base-content/80 max-w-3xl mx-auto mb-8 leading-relaxed">
+              Tell Go Daisy what you do — from surfing and stargazing to padel,
+              pilates and pub afternoons — and we&rsquo;ll read the wind,
+              waves, tides, UV and sky to tell you exactly when each one is on.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-3 justify-center items-center mb-4">
+              <Link
+                href={WEB_APP_CTA_URL}
+                className="btn btn-primary btn-lg w-full sm:w-auto"
+              >
+                Try the web app — free
+              </Link>
+              <a
+                href={APP_STORE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline btn-lg w-full sm:w-auto"
+              >
+                Download for iPhone
+              </a>
+            </div>
+
+            <p className="text-sm text-base-content/60">
+              Free, forever. No ads. No data sold. UK and Europe, 10 languages.
+              iOS today, Android in closed beta —{' '}
+              <a href="#android-testers" className="link link-primary">
+                help us launch
+              </a>
+              .
+            </p>
+
+            <div className="mt-6 inline-block badge badge-lg badge-ghost">
+              100+ activities. One weather-smart app. Outside <em>and</em> in.
+            </div>
+          </div>
+        </section>
+
+        {/* =================================================================
+            HOW IT WORKS
+            ================================================================= */}
+        <section className="px-4 py-16 bg-base-100">
+          <div className="max-w-5xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
+              How Go Daisy works
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="card bg-base-200 shadow-md">
+                <div className="card-body">
+                  <div className="text-4xl mb-2">🧡</div>
+                  <h3 className="card-title">1. Tell us what you love</h3>
+                  <p>
+                    Pick from over a hundred activities across sport, fitness,
+                    nature, winter, creative pursuits and indoor recreation.
+                    The more we know, the better we can read the weather for
+                    it.
+                  </p>
+                </div>
+              </div>
+              <div className="card bg-base-200 shadow-md">
+                <div className="card-body">
+                  <div className="text-4xl mb-2">🌤️</div>
+                  <h3 className="card-title">
+                    2. We read the conditions for each one
+                  </h3>
+                  <p>
+                    Wind, waves, tides, UV, pressure, cloud cover, sea
+                    temperature, snow conditions, moon phase, ISS passes, soil
+                    moisture. Not whether it&rsquo;s raining —{' '}
+                    <em>whether it&rsquo;s your kind of weather</em>.
+                  </p>
+                </div>
+              </div>
+              <div className="card bg-base-200 shadow-md">
+                <div className="card-body">
+                  <div className="text-4xl mb-2">✅</div>
+                  <h3 className="card-title">
+                    3. You get a &ldquo;go&rdquo; when conditions line up
+                  </h3>
+                  <p>
+                    Open the app and see what today is made for. And when
+                    the weather is properly grim? Go Daisy tells you that
+                    too — and what to do instead.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* =================================================================
+            ACTIVITIES — the SEO engine
+            ================================================================= */}
+        <section className="px-4 py-16 bg-base-200">
+          <div className="max-w-6xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-4">
+              What Go Daisy is for
+            </h2>
+            <p className="text-center text-base-content/80 max-w-2xl mx-auto mb-12">
+              Six worlds, more than a hundred ways to spend a day. Pick the
+              ones you do. Ignore the ones you don&rsquo;t.
+            </p>
+
+            <div className="space-y-10">
+              {ACTIVITY_CATEGORIES.map((category) => (
+                <div key={category.name} className="card bg-base-100 shadow-lg">
+                  <div className="card-body">
+                    <h3 className="card-title text-2xl mb-2">
+                      <span className="text-3xl mr-2" aria-hidden="true">
+                        {category.icon}
+                      </span>
+                      {category.name}
+                    </h3>
+                    <p className="text-base-content/80 mb-4">
+                      {category.description}
+                    </p>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {category.subCategories.map((sub) => (
+                        <div key={sub.name}>
+                          <h4 className="font-semibold text-base-content mb-2">
+                            {sub.name}
+                          </h4>
+                          <p className="text-sm text-base-content/70">
+                            {sub.activities.join(' · ')}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* =================================================================
+            WHAT WE READ
+            ================================================================= */}
+        <section className="px-4 py-16 bg-base-100">
+          <div className="max-w-5xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-6">
+              The conditions we watch so you don&rsquo;t have to
+            </h2>
+            <p className="text-center text-base-content/80 max-w-3xl mx-auto mb-10">
+              Professional-grade forecasts from OpenWeather, Stormglass marine
+              services and the Norwegian Meteorological Institute (api.met.no),
+              plus tide data and astronomy ephemerides. For any hour of any
+              day, Go Daisy can tell you:
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {[
+                {
+                  k: 'Air',
+                  v: 'Temperature, "feels like", humidity, dewpoint, UV index, pressure and pressure trend, air quality.',
+                },
+                {
+                  k: 'Wind',
+                  v: 'Speed, gust, direction — and how that direction matters for your spot.',
+                },
+                {
+                  k: 'Wet',
+                  v: 'Rainfall in the last 24 hours, rainfall in the next 6, snow, cloud cover, fog risk.',
+                },
+                {
+                  k: 'Sea',
+                  v: 'Wave height, swell period and direction, sea surface temperature, tide times and heights.',
+                },
+                {
+                  k: 'Sky',
+                  v: 'Sunrise, sunset, civil/nautical/astronomical twilight, moonrise, moonset, moon phase and illumination, ISS pass-overs.',
+                },
+                {
+                  k: 'Ground',
+                  v: 'Soil temperature and soil moisture for gardeners, snow depth and freeze-thaw cycles for winter sports.',
+                },
+              ].map((item) => (
+                <div key={item.k} className="card bg-base-200">
+                  <div className="card-body p-5">
+                    <h3 className="text-lg font-semibold">{item.k}</h3>
+                    <p className="text-sm text-base-content/80">{item.v}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <p className="text-center mt-8 text-base-content/80 max-w-2xl mx-auto">
+              For each activity you have told us you care about, we score how
+              good <em>this hour</em> is for <em>that thing</em>. No mental
+              arithmetic required.
+            </p>
+          </div>
+        </section>
+
+        {/* =================================================================
+            TOP FAQS
+            ================================================================= */}
+        <section className="px-4 py-16 bg-base-200">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-10">
+              Frequently asked questions
+            </h2>
+
+            <div className="join join-vertical w-full">
+              {TOP_FAQS.map((faq, i) => (
+                <div
+                  key={faq.q}
+                  className="collapse collapse-arrow join-item border border-base-300 bg-base-100"
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={faq.q}
+                    defaultChecked={i === 0}
+                  />
+                  <h3 className="collapse-title text-lg font-medium">
+                    {faq.q}
+                  </h3>
+                  <div className="collapse-content">
+                    <p>{faq.a}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="text-center mt-8">
+              <Link href="/faq" className="link link-primary">
+                See the full FAQ &rarr;
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* =================================================================
+            ANDROID TESTER RECRUITMENT
+            ================================================================= */}
+        <section
+          id="android-testers"
+          className="px-4 py-16 bg-gradient-to-b from-base-100 to-base-200"
+        >
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="text-5xl mb-4" aria-hidden="true">
+              🤖
+            </div>
+            <h2 className="text-3xl md:text-4xl font-bold mb-6">
+              Help us launch on Android.
+            </h2>
+            <p className="text-lg text-base-content/80 mb-6 leading-relaxed">
+              The Android version of Go Daisy is built and ready. Google Play
+              asks us to find twelve testers to use it on real Android phones
+              for two weeks before we can release it to the world — so
+              that&rsquo;s what we&rsquo;re doing.
+            </p>
+
+            <ul className="text-left max-w-xl mx-auto mb-8 space-y-2 text-base-content/80">
+              <li>
+                <span className="text-success">✓</span> Early access to Go
+                Daisy on Android, before anyone else
+              </li>
+              <li>
+                <span className="text-success">✓</span> Free lifetime access
+                to our specialist sister apps (Findr, Rise Daisy, Grow Daisy)
+                when they ship on Android
+              </li>
+              <li>
+                <span className="text-success">✓</span> A direct line to us
+                for feedback
+              </li>
+            </ul>
+
+            <p className="text-sm text-base-content/70 mb-6">
+              About ten minutes a week of normal use. No bug-hunting expected.
+              We just need real phones in real hands for the fortnight Google
+              needs.
+            </p>
+
+            {/*
+              TODO: wire this button to a real sign-up form.
+              Simplest path: a Supabase table `android_testers` with columns
+              email, country, primary_activity, created_at — and a Resend
+              confirmation email. See the Android tester recruitment plan
+              for details.
+            */}
+            <Link
+              href="/android-testers"
+              className="btn btn-primary btn-lg"
+            >
+              Sign me up as an Android tester &rarr;
+            </Link>
+          </div>
+        </section>
+
+        {/* =================================================================
+            FINAL CTA
+            ================================================================= */}
+        <section className="px-4 py-20 bg-base-100">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Get out there. Or in. Whichever today asks for.
+            </h2>
+            <p className="text-lg text-base-content/80 mb-8 max-w-2xl mx-auto">
+              Download Go Daisy for iPhone, or open the web app and tell us
+              what you love. The forecast looks a lot more interesting when
+              it&rsquo;s pointed at the things you actually do.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href={WEB_APP_CTA_URL}
+                className="btn btn-primary btn-lg"
+              >
+                Try the web app — free
+              </Link>
+              <a
+                href={APP_STORE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline btn-lg"
+              >
+                Download for iPhone
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* =================================================================
+            TRUST / FOOTER STRIP
+            ================================================================= */}
+        <section className="px-4 py-10 bg-base-200 border-t border-base-300">
+          <div className="max-w-4xl mx-auto text-center text-sm text-base-content/70">
+            <p className="mb-2">
+              Built by independent makers in the UK and Asturias, Spain.
+            </p>
+            <p>
+              Free for everyone, forever — supported by our specialist sister
+              apps, not by ads or by selling your data. Weather data from
+              OpenWeather, Stormglass and api.met.no.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+};
+
+export default LandingPage;

--- a/data/seoLocations.ts
+++ b/data/seoLocations.ts
@@ -1,0 +1,563 @@
+/**
+ * SEO location dataset — every place that gets a programmatic page generated
+ * at /[activity]/[location-slug].
+ *
+ * Coverage:
+ *   - All 44 European capital cities
+ *   - Top 50 North American cities by population (US, Canada, Mexico mixed)
+ *   - Hand-picked Asturias, UK surf and mountain locations
+ *
+ * Page count: ~100 locations × curated activities per location = ~2,000 pages.
+ *
+ * Activities per location are curated by archetype below. A "surf city" gets
+ * surfing in its list; Madrid does not. This is the single most important
+ * lever for keeping these pages high-quality — generating "/surfing/madrid"
+ * because we *could* would invite a doorway-page penalty.
+ *
+ * To add a location: append to the cities array at the bottom of this file.
+ * To change which activities a city covers: edit its `activities` array
+ * (or change the archetype it composes from).
+ */
+
+// ============================================================================
+// Activity archetypes — sets of activity IDs grouped by what kind of place
+// would plausibly do them. A city composes its activity list from one or
+// more of these, plus any explicit additions/removals.
+// ============================================================================
+
+/** Things you can do in any walkable city, anywhere with weather. */
+const UNIVERSAL = [
+  'running',
+  'cycling',
+  'urban_exploring',
+  'photography',
+  'outdoor_yoga',
+  'outdoor_meditation',
+  'yoga',
+  'meditation',
+  'pilates',
+  'gym_workout',
+  'tai_chi',
+  'padel',
+  'tennis',
+  'tennis_indoor',
+  'pickleball',
+  'basketball_outdoor',
+  'table_tennis',
+  'badminton',
+  'squash',
+  'going_to_pub',
+  'cafe',
+  'cinema',
+  'museum',
+  'gallery',
+  'shopping',
+  'bowling',
+  'dance',
+  'reading',
+  'outdoor_reading',
+  'picnicking',
+  'bbq',
+  'dog_walking',
+  'outdoor_painting',
+  'outdoor_chess',
+  'outdoor_music',
+];
+
+/** Coastal additions — open ocean or large saltwater bay nearby. */
+const COASTAL = [
+  'surfing',
+  'sea_swimming',
+  'sea_kayaking',
+  'stand_up_paddleboarding',
+  'sup_sea',
+  'sailing',
+  'snorkeling',
+  'scuba_diving',
+  'windsurfing',
+  'kitesurfing',
+  'jet_skiing',
+  'sea_fishing_shore',
+  'sea_fishing_boat',
+  'beach',
+  'beach_volleyball',
+  'rock_hopping',
+];
+
+/** Coastal additions for places where the surf isn't great but the sea is usable. */
+const COASTAL_NO_SURF = COASTAL.filter((a) => a !== 'surfing');
+
+/** Inland water — rivers, lakes, reservoirs. */
+const INLAND_WATER = [
+  'kayaking',
+  'canoeing',
+  'sailing_inland',
+  'windsurfing_inland',
+  'wild_swimming',
+  'indoor_swimming',
+  'fly_fishing_freshwater',
+  'coarse_fishing',
+];
+
+/** Hills, mountains and trails nearby. */
+const MOUNTAINOUS = [
+  'hiking',
+  'trail_running',
+  'rock_climbing',
+  'rock_hopping',
+  'mountain_biking',
+  'gravel_biking',
+  'birdwatching',
+  'foraging',
+  'mushroom_hunting',
+  'stargazing',
+];
+
+/** Cold-climate winter sports zone (Alps, Pyrenees, Scandinavia, mountain US). */
+const WINTER_SPORTS = [
+  'skiing',
+  'snowboarding',
+  'cross_country_skiing',
+  'ice_skating',
+  'ice_hockey',
+  'ice_hockey_indoor',
+  'ice_fishing',
+];
+
+/** Indoor / weather-bad-day fallbacks (always include — every city has these). */
+const INDOOR_ALWAYS = [
+  'crafts',
+  'knitting',
+  'diy',
+  'cooking',
+  'playing_records',
+  'make_music',
+  'gaming',
+  'online',
+  'playing_cards',
+  'watch_a_movie',
+  'painting',
+  'indoor_climbing',
+  'indoor_swimming',
+  'volleyball_indoor',
+  'archery',
+  'boxing',
+  'spinning',
+  'zumba',
+  'martial_arts',
+];
+
+/** Garden / outdoor-domestic activities (most cities have them). */
+const GARDEN = ['outdoor_gardening'];
+
+/** Major outdoor team sports — typically scored for outdoor pitches. */
+const TEAM_SPORTS_GLOBAL = [
+  'football_soccer',
+  'rugby',
+  'cricket',
+  'hockey',
+  'netball',
+  'beach_volleyball',
+];
+
+/** Team sports skewed to the US market. */
+const TEAM_SPORTS_US = [
+  'american_football',
+  'baseball',
+  'basketball_outdoor',
+];
+
+/** Team sports for Ireland. */
+const TEAM_SPORTS_IRELAND = ['hurling_camogie', 'gaelic_football'];
+
+/** Convenience to dedupe an activity list while preserving order. */
+function dedupe(arr: string[]): string[] {
+  return Array.from(new Set(arr));
+}
+
+/** Archetype: inland European city — no surfing, no winter sports. */
+function inlandEuropean(extra: string[] = []): string[] {
+  return dedupe([
+    ...UNIVERSAL,
+    ...INLAND_WATER,
+    ...MOUNTAINOUS.filter((a) =>
+      ['hiking', 'birdwatching', 'foraging', 'stargazing'].includes(a)
+    ),
+    ...TEAM_SPORTS_GLOBAL,
+    ...INDOOR_ALWAYS,
+    ...GARDEN,
+    ...extra,
+  ]);
+}
+
+/** Archetype: coastal European city — saltwater + city stuff. */
+function coastalEuropean(extra: string[] = []): string[] {
+  return dedupe([
+    ...UNIVERSAL,
+    ...COASTAL,
+    ...INLAND_WATER,
+    ...TEAM_SPORTS_GLOBAL,
+    ...INDOOR_ALWAYS,
+    ...GARDEN,
+    ...extra,
+  ]);
+}
+
+/** Archetype: coastal European city without proper surf (e.g. Med, Baltic). */
+function coastalEuropeanNoSurf(extra: string[] = []): string[] {
+  return dedupe([
+    ...UNIVERSAL,
+    ...COASTAL_NO_SURF,
+    ...INLAND_WATER,
+    ...TEAM_SPORTS_GLOBAL,
+    ...INDOOR_ALWAYS,
+    ...GARDEN,
+    ...extra,
+  ]);
+}
+
+/** Archetype: Alpine / mountain city — winter sports active. */
+function alpineCity(extra: string[] = []): string[] {
+  return dedupe([
+    ...UNIVERSAL,
+    ...INLAND_WATER,
+    ...MOUNTAINOUS,
+    ...WINTER_SPORTS,
+    ...TEAM_SPORTS_GLOBAL,
+    ...INDOOR_ALWAYS,
+    ...GARDEN,
+    ...extra,
+  ]);
+}
+
+/** Archetype: inland US city — adds American team sports. */
+function inlandUS(extra: string[] = []): string[] {
+  return dedupe([
+    ...UNIVERSAL,
+    ...INLAND_WATER,
+    ...MOUNTAINOUS.filter((a) =>
+      ['hiking', 'birdwatching', 'foraging', 'stargazing'].includes(a)
+    ),
+    ...TEAM_SPORTS_US,
+    ...TEAM_SPORTS_GLOBAL.filter((a) => a !== 'cricket' && a !== 'netball'),
+    ...INDOOR_ALWAYS,
+    ...GARDEN,
+    ...extra,
+  ]);
+}
+
+/** Archetype: coastal US city. */
+function coastalUS(extra: string[] = []): string[] {
+  return dedupe([
+    ...UNIVERSAL,
+    ...COASTAL,
+    ...INLAND_WATER,
+    ...TEAM_SPORTS_US,
+    ...TEAM_SPORTS_GLOBAL.filter((a) => a !== 'cricket' && a !== 'netball'),
+    ...INDOOR_ALWAYS,
+    ...GARDEN,
+    ...extra,
+  ]);
+}
+
+// ============================================================================
+// Location type
+// ============================================================================
+
+export interface SeoLocation {
+  slug: string;
+  name: string;
+  region: string;
+  country: string;
+  lat: number;
+  lon: number;
+  timezone: string;
+  activities: string[];
+  beachFacingDeg?: number | null;
+  description?: string;
+}
+
+// ============================================================================
+// The cities
+// ============================================================================
+
+export const SEO_LOCATIONS: SeoLocation[] = [
+  // ===========================================================================
+  // ASTURIAS, SPAIN — local market, low competition
+  // ===========================================================================
+  {
+    slug: 'llanes-asturias',
+    name: 'Llanes',
+    region: 'Asturias',
+    country: 'Spain',
+    lat: 43.4198,
+    lon: -4.7541,
+    timezone: 'Europe/Madrid',
+    activities: coastalEuropean(['fly_fishing_freshwater']),
+    beachFacingDeg: 0,
+    description:
+      'Llanes sits on the Asturian coast where limestone sea cliffs, sheltered coves and Atlantic surf beaches are within a ten-minute drive of each other.',
+  },
+  {
+    slug: 'tapia-de-casariego-asturias',
+    name: 'Tapia de Casariego',
+    region: 'Asturias',
+    country: 'Spain',
+    lat: 43.5667,
+    lon: -6.9442,
+    timezone: 'Europe/Madrid',
+    activities: coastalEuropean(),
+    beachFacingDeg: 350,
+    description:
+      'Tapia is the surf capital of the Asturian west coast — host of the long-running Tapia Pro and an Atlantic-facing reef that picks up almost any swell from the north or west.',
+  },
+  {
+    slug: 'salinas-asturias',
+    name: 'Salinas',
+    region: 'Asturias',
+    country: 'Spain',
+    lat: 43.5786,
+    lon: -5.9614,
+    timezone: 'Europe/Madrid',
+    activities: coastalEuropean(),
+    beachFacingDeg: 5,
+    description:
+      'Salinas is the long, sandy beach above Avilés — a forgiving wave for intermediates and the home of the Salinas Longboard Festival.',
+  },
+  {
+    slug: 'picos-de-europa',
+    name: 'Picos de Europa',
+    region: 'Asturias',
+    country: 'Spain',
+    lat: 43.1944,
+    lon: -4.8500,
+    timezone: 'Europe/Madrid',
+    activities: alpineCity(),
+    description:
+      'One of the wildest mountain ranges in Western Europe — limestone peaks that touch 2,600m within 15km of the Atlantic, creating their own weather.',
+  },
+
+  // ===========================================================================
+  // UK SURF, COAST, AND HILLS
+  // ===========================================================================
+  {
+    slug: 'newquay-cornwall',
+    name: 'Newquay',
+    region: 'Cornwall',
+    country: 'United Kingdom',
+    lat: 50.4156,
+    lon: -5.0750,
+    timezone: 'Europe/London',
+    activities: coastalEuropean(),
+    beachFacingDeg: 310,
+    description:
+      'The UK\'s best-known surf town — Fistral picks up almost every Atlantic swell, with a range of bays inside Newquay for less exposed conditions.',
+  },
+  {
+    slug: 'brighton-sussex',
+    name: 'Brighton',
+    region: 'East Sussex',
+    country: 'United Kingdom',
+    lat: 50.8225,
+    lon: -0.1372,
+    timezone: 'Europe/London',
+    activities: coastalEuropeanNoSurf(),
+    beachFacingDeg: 180,
+    description:
+      'South-facing pebble beach, Channel swell, a year-round wild swimming community, and a train line from London.',
+  },
+  {
+    slug: 'tynemouth-northumberland',
+    name: 'Tynemouth',
+    region: 'Northumberland',
+    country: 'United Kingdom',
+    lat: 55.0174,
+    lon: -1.4244,
+    timezone: 'Europe/London',
+    activities: coastalEuropean(),
+    beachFacingDeg: 65,
+    description:
+      'Longsands is the North-East\'s biggest surf beach — east-facing, exposed to North Sea swells, and home to one of the UK\'s most committed cold-water surfing communities.',
+  },
+  {
+    slug: 'lake-district-cumbria',
+    name: 'Lake District',
+    region: 'Cumbria',
+    country: 'United Kingdom',
+    lat: 54.4609,
+    lon: -3.0886,
+    timezone: 'Europe/London',
+    activities: alpineCity().filter((a) => a !== 'skiing' && a !== 'snowboarding' && a !== 'cross_country_skiing'),
+    description:
+      'England\'s deepest lakes, highest mountains, and most variable weather. A morning of perfect light can turn to a Lakeland deluge by lunchtime.',
+  },
+  {
+    slug: 'snowdonia-eryri',
+    name: 'Snowdonia (Eryri)',
+    region: 'Gwynedd',
+    country: 'United Kingdom',
+    lat: 53.0685,
+    lon: -4.0763,
+    timezone: 'Europe/London',
+    activities: alpineCity().filter((a) => a !== 'skiing' && a !== 'snowboarding'),
+    description:
+      'The highest mountain region of Wales — and a designated International Dark Sky Reserve, so it doubles as one of the UK\'s best stargazing locations.',
+  },
+  {
+    slug: 'biarritz-pays-basque',
+    name: 'Biarritz',
+    region: 'Pays Basque',
+    country: 'France',
+    lat: 43.4832,
+    lon: -1.5586,
+    timezone: 'Europe/Paris',
+    activities: coastalEuropean(),
+    beachFacingDeg: 290,
+    description:
+      'Where European surfing began. Consistent Atlantic swell, a Basque culinary scene, and the Pyrenees an hour away.',
+  },
+
+  // ===========================================================================
+  // EUROPEAN CAPITALS — alphabetical
+  // ===========================================================================
+  { slug: 'amsterdam', name: 'Amsterdam', region: 'North Holland', country: 'Netherlands', lat: 52.3676, lon: 4.9041, timezone: 'Europe/Amsterdam', activities: inlandEuropean(), description: 'Famously flat, famously cycle-friendly, and one of the easiest cities in Europe to live outdoors on a bike.' },
+  { slug: 'andorra-la-vella', name: 'Andorra la Vella', region: 'Andorra la Vella', country: 'Andorra', lat: 42.5063, lon: 1.5218, timezone: 'Europe/Andorra', activities: alpineCity(), description: 'A Pyrenean capital where the ski lifts are inside the city limits.' },
+  { slug: 'athens', name: 'Athens', region: 'Attica', country: 'Greece', lat: 37.9838, lon: 23.7275, timezone: 'Europe/Athens', activities: coastalEuropeanNoSurf(), description: 'Mediterranean coast on one side, the Pindus foothills on the other, and a climate that rewards being outside ten months of the year.' },
+  { slug: 'belgrade', name: 'Belgrade', region: 'Belgrade', country: 'Serbia', lat: 44.7866, lon: 20.4489, timezone: 'Europe/Belgrade', activities: inlandEuropean(), description: 'Where the Sava meets the Danube — two of Europe\'s great rivers, with kayaking, rowing and wild swimming all on the city map.' },
+  { slug: 'berlin', name: 'Berlin', region: 'Berlin', country: 'Germany', lat: 52.5200, lon: 13.4050, timezone: 'Europe/Berlin', activities: inlandEuropean(), description: 'Lakes, forests and a famously thorough cycle network — most things outdoor are a 30-minute S-Bahn ride away.' },
+  { slug: 'bern', name: 'Bern', region: 'Bern', country: 'Switzerland', lat: 46.9480, lon: 7.4474, timezone: 'Europe/Zurich', activities: alpineCity(), description: 'The Aare loops through the old town, and the Bernese Oberland mountains rise an hour to the south.' },
+  { slug: 'bratislava', name: 'Bratislava', region: 'Bratislava', country: 'Slovakia', lat: 48.1486, lon: 17.1077, timezone: 'Europe/Bratislava', activities: inlandEuropean(), description: 'The Little Carpathians sit on the city\'s western doorstep, with the Danube on its southern.' },
+  { slug: 'brussels', name: 'Brussels', region: 'Brussels-Capital', country: 'Belgium', lat: 50.8503, lon: 4.3517, timezone: 'Europe/Brussels', activities: inlandEuropean(), description: 'The Sonian Forest covers a quarter of the city — half an hour from Grand Place by bike.' },
+  { slug: 'bucharest', name: 'Bucharest', region: 'Bucharest', country: 'Romania', lat: 44.4268, lon: 26.1025, timezone: 'Europe/Bucharest', activities: inlandEuropean(), description: 'Within two hours of the Carpathians and three hours of the Black Sea — Bucharest changes shape with the seasons.' },
+  { slug: 'budapest', name: 'Budapest', region: 'Budapest', country: 'Hungary', lat: 47.4979, lon: 19.0402, timezone: 'Europe/Budapest', activities: inlandEuropean(), description: 'The Danube runs through it and the Buda hills rise on its western side.' },
+  { slug: 'chisinau', name: 'Chișinău', region: 'Chișinău', country: 'Moldova', lat: 47.0105, lon: 28.8638, timezone: 'Europe/Chisinau', activities: inlandEuropean(), description: 'Continental climate, vineyards on its outskirts, and surprisingly green public parks.' },
+  { slug: 'copenhagen', name: 'Copenhagen', region: 'Capital Region', country: 'Denmark', lat: 55.6761, lon: 12.5683, timezone: 'Europe/Copenhagen', activities: coastalEuropeanNoSurf(['ice_skating']), description: 'Sea on three sides, more bikes than cars, and a city-wide tradition of harbour swimming year-round.' },
+  { slug: 'dublin', name: 'Dublin', region: 'Leinster', country: 'Ireland', lat: 53.3498, lon: -6.2603, timezone: 'Europe/Dublin', activities: coastalEuropean([...TEAM_SPORTS_IRELAND]), description: 'Dublin Bay on the east, the Wicklow Mountains a half-hour south, and GAA pitches in every parish.' },
+  { slug: 'helsinki', name: 'Helsinki', region: 'Uusimaa', country: 'Finland', lat: 60.1699, lon: 24.9384, timezone: 'Europe/Helsinki', activities: coastalEuropeanNoSurf([...WINTER_SPORTS]), description: 'Built across a Baltic archipelago — long summer evenings, hard winters, sauna culture, and ice swimming.' },
+  { slug: 'kyiv', name: 'Kyiv', region: 'Kyiv', country: 'Ukraine', lat: 50.4501, lon: 30.5234, timezone: 'Europe/Kyiv', activities: inlandEuropean(['ice_skating']), description: 'The Dnipro splits the city north–south; pine forests and freshwater beaches sit on its eastern bank.' },
+  { slug: 'lisbon', name: 'Lisbon', region: 'Lisbon', country: 'Portugal', lat: 38.7223, lon: -9.1393, timezone: 'Europe/Lisbon', activities: coastalEuropean(), beachFacingDeg: 240, description: 'The Tagus on one side, Atlantic surf beaches 30 minutes away on the other, and 300 days of sunshine a year.' },
+  { slug: 'ljubljana', name: 'Ljubljana', region: 'Central Slovenia', country: 'Slovenia', lat: 46.0569, lon: 14.5058, timezone: 'Europe/Ljubljana', activities: alpineCity(), description: 'Forty minutes to the Julian Alps for skiing in winter and trail running in summer; the Adriatic an hour away in the other direction.' },
+  { slug: 'london', name: 'London', region: 'Greater London', country: 'United Kingdom', lat: 51.5074, lon: -0.1278, timezone: 'Europe/London', activities: inlandEuropean(['fly_fishing_freshwater']), description: 'The Thames, eight royal parks, three thousand kilometres of cycleway, and a borough-by-borough cricket and rugby culture.' },
+  { slug: 'luxembourg', name: 'Luxembourg City', region: 'Luxembourg', country: 'Luxembourg', lat: 49.6116, lon: 6.1319, timezone: 'Europe/Luxembourg', activities: inlandEuropean(), description: 'Mosel valley to the east, Ardennes to the north, and a hilly old town that makes walking it count as exercise.' },
+  { slug: 'madrid', name: 'Madrid', region: 'Madrid', country: 'Spain', lat: 40.4168, lon: -3.7038, timezone: 'Europe/Madrid', activities: inlandEuropean(['skiing', 'snowboarding']), description: 'A continental capital ringed by the Sierra de Guadarrama — high enough to ski in winter, dry enough to play padel four hundred days a year.' },
+  { slug: 'minsk', name: 'Minsk', region: 'Minsk', country: 'Belarus', lat: 53.9006, lon: 27.5590, timezone: 'Europe/Minsk', activities: inlandEuropean([...WINTER_SPORTS.filter((a) => a !== 'skiing')]), description: 'Long, real winters, flat terrain, and a city plan built around its lakes and the Svislach river.' },
+  { slug: 'monaco', name: 'Monaco', region: 'Monaco', country: 'Monaco', lat: 43.7384, lon: 7.4246, timezone: 'Europe/Monaco', activities: coastalEuropeanNoSurf(), description: 'Mediterranean on its doorstep, Alpes-Maritimes 20 minutes inland — the smallest place on this list, the highest density of outdoor options per square kilometre.' },
+  { slug: 'nicosia', name: 'Nicosia', region: 'Nicosia', country: 'Cyprus', lat: 35.1856, lon: 33.3823, timezone: 'Asia/Nicosia', activities: inlandEuropean(['scuba_diving', 'sea_swimming']), description: 'The Mediterranean is 40 minutes south and the Troodos mountains an hour west.' },
+  { slug: 'oslo', name: 'Oslo', region: 'Oslo', country: 'Norway', lat: 59.9139, lon: 10.7522, timezone: 'Europe/Oslo', activities: alpineCity(), description: 'Cross-country ski trails inside the city limits. Fjord on the doorstep. Sauna boats on the harbour year-round.' },
+  { slug: 'paris', name: 'Paris', region: 'Île-de-France', country: 'France', lat: 48.8566, lon: 2.3522, timezone: 'Europe/Paris', activities: inlandEuropean(), description: 'The Seine, the bois on either side, and a national obsession with the Sunday outdoor lunch.' },
+  { slug: 'podgorica', name: 'Podgorica', region: 'Podgorica', country: 'Montenegro', lat: 42.4304, lon: 19.2594, timezone: 'Europe/Podgorica', activities: alpineCity(), description: 'Between Skadar Lake and the Dinaric Alps, with the Adriatic 45 minutes away.' },
+  { slug: 'prague', name: 'Prague', region: 'Prague', country: 'Czech Republic', lat: 50.0755, lon: 14.4378, timezone: 'Europe/Prague', activities: inlandEuropean(), description: 'The Vltava cuts through it, and Bohemia rolls outwards into hills, forests and beer gardens.' },
+  { slug: 'pristina', name: 'Pristina', region: 'Pristina', country: 'Kosovo', lat: 42.6629, lon: 21.1655, timezone: 'Europe/Belgrade', activities: alpineCity(), description: 'The Sharr Mountains form a long ridge to the south, with Brezovica\'s ski runs an hour and a half away.' },
+  { slug: 'reykjavik', name: 'Reykjavík', region: 'Capital Region', country: 'Iceland', lat: 64.1466, lon: -21.9426, timezone: 'Atlantic/Reykjavik', activities: coastalEuropean([...WINTER_SPORTS]), description: 'A geothermal capital where the aurora is a weather forecast question and the sea swim is a year-round one.' },
+  { slug: 'riga', name: 'Riga', region: 'Riga', country: 'Latvia', lat: 56.9496, lon: 24.1052, timezone: 'Europe/Riga', activities: coastalEuropeanNoSurf([...WINTER_SPORTS.filter((a) => a !== 'skiing')]), description: 'On the Gulf of Riga with the Daugava river running through it — flat, wooded, and made for cycling.' },
+  { slug: 'rome', name: 'Rome', region: 'Lazio', country: 'Italy', lat: 41.9028, lon: 12.4964, timezone: 'Europe/Rome', activities: inlandEuropean(['sea_swimming']), description: 'The Tiber, three hills, and Ostia\'s beach 30 minutes by train.' },
+  { slug: 'san-marino', name: 'San Marino', region: 'San Marino', country: 'San Marino', lat: 43.9424, lon: 12.4578, timezone: 'Europe/San_Marino', activities: inlandEuropean(['rock_climbing']), description: 'Three hilltop towers on Monte Titano, with the Adriatic 15 minutes east at Rimini.' },
+  { slug: 'sarajevo', name: 'Sarajevo', region: 'Sarajevo Canton', country: 'Bosnia and Herzegovina', lat: 43.8563, lon: 18.4131, timezone: 'Europe/Sarajevo', activities: alpineCity(), description: 'Mount Bjelašnica on its southern edge — Olympic ski runs 25km from the old town.' },
+  { slug: 'skopje', name: 'Skopje', region: 'Skopje', country: 'North Macedonia', lat: 41.9981, lon: 21.4254, timezone: 'Europe/Skopje', activities: alpineCity(), description: 'Mount Vodno rises above the city; Mavrovo and Popova Šapka are within day-trip distance.' },
+  { slug: 'sofia', name: 'Sofia', region: 'Sofia City', country: 'Bulgaria', lat: 42.6977, lon: 23.3219, timezone: 'Europe/Sofia', activities: alpineCity(), description: 'Vitosha Mountain begins where the tram lines end — a working ski hill that\'s legitimately part of the city.' },
+  { slug: 'stockholm', name: 'Stockholm', region: 'Stockholm County', country: 'Sweden', lat: 59.3293, lon: 18.0686, timezone: 'Europe/Stockholm', activities: coastalEuropeanNoSurf([...WINTER_SPORTS]), description: 'Built across 14 islands in the Baltic archipelago — kayaking and swimming in summer, ice skating in winter.' },
+  { slug: 'tallinn', name: 'Tallinn', region: 'Harju', country: 'Estonia', lat: 59.4370, lon: 24.7536, timezone: 'Europe/Tallinn', activities: coastalEuropeanNoSurf([...WINTER_SPORTS.filter((a) => a !== 'skiing')]), description: 'On the Gulf of Finland, with the medieval old town opening onto pine forests and bog-walking trails.' },
+  { slug: 'tirana', name: 'Tirana', region: 'Tirana', country: 'Albania', lat: 41.3275, lon: 19.8187, timezone: 'Europe/Tirane', activities: alpineCity(['sea_swimming']), description: 'Mount Dajti on one side, the Adriatic 40 minutes the other — a capital with both summer beach days and winter ski days within an hour.' },
+  { slug: 'vaduz', name: 'Vaduz', region: 'Oberland', country: 'Liechtenstein', lat: 47.1410, lon: 9.5209, timezone: 'Europe/Vaduz', activities: alpineCity(), description: 'A Rhine-valley capital wedged between Swiss and Austrian Alps — small enough to walk across in fifteen minutes, mountainous enough to ski from its outskirts.' },
+  { slug: 'valletta', name: 'Valletta', region: 'Valletta', country: 'Malta', lat: 35.8989, lon: 14.5146, timezone: 'Europe/Malta', activities: coastalEuropeanNoSurf(), description: 'A walkable Mediterranean fortress city — every street ends in sea, and the scuba diving on the surrounding coast is some of Europe\'s best.' },
+  { slug: 'vienna', name: 'Vienna', region: 'Vienna', country: 'Austria', lat: 48.2082, lon: 16.3738, timezone: 'Europe/Vienna', activities: alpineCity(), description: 'The Danube, the Vienna Woods on the western edge, and a tram to ski slopes within an hour.' },
+  { slug: 'vilnius', name: 'Vilnius', region: 'Vilnius County', country: 'Lithuania', lat: 54.6872, lon: 25.2797, timezone: 'Europe/Vilnius', activities: inlandEuropean([...WINTER_SPORTS.filter((a) => a !== 'skiing')]), description: 'Forest covers more of the city than buildings; the Neris and Vilnia rivers run through it and lakes ring its outskirts.' },
+  { slug: 'warsaw', name: 'Warsaw', region: 'Masovian', country: 'Poland', lat: 52.2297, lon: 21.0122, timezone: 'Europe/Warsaw', activities: inlandEuropean(['ice_skating']), description: 'The Vistula with its wild eastern bank, the Kampinos Forest a tram-ride away, and proper winters most years.' },
+  { slug: 'zagreb', name: 'Zagreb', region: 'City of Zagreb', country: 'Croatia', lat: 45.8150, lon: 15.9819, timezone: 'Europe/Zagreb', activities: alpineCity(), description: 'Medvednica rises on the city\'s northern edge — a wooded mountain with a working ski hill and trail networks for hiking and gravel.' },
+
+  // ===========================================================================
+  // TOP 50 NORTH AMERICAN CITIES BY POPULATION
+  // (mix of US, Canadian and Mexican cities by city-proper population)
+  // ===========================================================================
+  { slug: 'mexico-city', name: 'Mexico City', region: 'Mexico City', country: 'Mexico', lat: 19.4326, lon: -99.1332, timezone: 'America/Mexico_City', activities: inlandEuropean(['rock_climbing']), description: 'At 2,240m elevation and ringed by volcanoes — the highest-altitude megacity on the continent.' },
+  { slug: 'new-york', name: 'New York', region: 'New York', country: 'United States', lat: 40.7128, lon: -74.0060, timezone: 'America/New_York', activities: coastalUS(), description: 'Five boroughs, two rivers, the Atlantic on one flank and the Hudson Valley on the other.' },
+  { slug: 'los-angeles', name: 'Los Angeles', region: 'California', country: 'United States', lat: 34.0522, lon: -118.2437, timezone: 'America/Los_Angeles', activities: coastalUS(), beachFacingDeg: 245, description: 'A coastal city stretched along 75 miles of Pacific — surfing on Tuesday, San Gabriel hiking on Wednesday.' },
+  { slug: 'toronto', name: 'Toronto', region: 'Ontario', country: 'Canada', lat: 43.6532, lon: -79.3832, timezone: 'America/Toronto', activities: coastalEuropeanNoSurf([...TEAM_SPORTS_US, 'ice_hockey', 'ice_skating']), description: 'On the north shore of Lake Ontario — sailing in summer, hard ice in winter, and a year-round ravine system that feels rural for an hour at a time.' },
+  { slug: 'chicago', name: 'Chicago', region: 'Illinois', country: 'United States', lat: 41.8781, lon: -87.6298, timezone: 'America/Chicago', activities: coastalUS().filter((a) => a !== 'surfing' && a !== 'jet_skiing'), description: 'On Lake Michigan — 26 miles of public lakefront, a famous summer running culture, and proper winters.' },
+  { slug: 'houston', name: 'Houston', region: 'Texas', country: 'United States', lat: 29.7604, lon: -95.3698, timezone: 'America/Chicago', activities: inlandUS(['sea_kayaking', 'sea_fishing_boat']), description: 'Subtropical, hurricane-aware, and an hour from Galveston Bay.' },
+  { slug: 'ecatepec', name: 'Ecatepec', region: 'State of Mexico', country: 'Mexico', lat: 19.6011, lon: -99.0500, timezone: 'America/Mexico_City', activities: inlandEuropean(), description: 'High-altitude Mexico City metro — same climate, same volcanic ring, dryer southern outskirts.' },
+  { slug: 'phoenix', name: 'Phoenix', region: 'Arizona', country: 'United States', lat: 33.4484, lon: -112.0740, timezone: 'America/Phoenix', activities: inlandUS(), description: 'A desert city where summer pushes activities to dawn and dusk — and the South Mountain trails are walkable from downtown.' },
+  { slug: 'philadelphia', name: 'Philadelphia', region: 'Pennsylvania', country: 'United States', lat: 39.9526, lon: -75.1652, timezone: 'America/New_York', activities: inlandUS(), description: 'The Schuylkill and Delaware rivers run through it, the Wissahickon ravine cuts inside the city limits, and the Jersey shore is 90 minutes east.' },
+  { slug: 'tijuana', name: 'Tijuana', region: 'Baja California', country: 'Mexico', lat: 32.5149, lon: -117.0382, timezone: 'America/Tijuana', activities: coastalEuropean(), beachFacingDeg: 270, description: 'Pacific-facing border city — proper surf to the south at Rosarito and Ensenada, and the Sierra de Juárez an hour inland.' },
+  { slug: 'san-antonio', name: 'San Antonio', region: 'Texas', country: 'United States', lat: 29.4241, lon: -98.4936, timezone: 'America/Chicago', activities: inlandUS(), description: 'Hill country to the north, river walk through the centre, and a long shoulder season for outdoor sport.' },
+  { slug: 'san-diego', name: 'San Diego', region: 'California', country: 'United States', lat: 32.7157, lon: -117.1611, timezone: 'America/Los_Angeles', activities: coastalUS(), beachFacingDeg: 250, description: 'A consistent 18°C climate, 70 miles of Pacific coast, and the closest US city to Baja\'s surf and diving.' },
+  { slug: 'dallas', name: 'Dallas', region: 'Texas', country: 'United States', lat: 32.7767, lon: -96.7970, timezone: 'America/Chicago', activities: inlandUS(), description: 'Flat, hot, and surprisingly green — lakes ring the city and the cycle network is improving fast.' },
+  { slug: 'puebla', name: 'Puebla', region: 'Puebla', country: 'Mexico', lat: 19.0413, lon: -98.2062, timezone: 'America/Mexico_City', activities: alpineCity(), description: 'In the shadow of Popocatépetl and Iztaccíhuatl — a colonial capital where the volcanoes set the weather.' },
+  { slug: 'austin', name: 'Austin', region: 'Texas', country: 'United States', lat: 30.2672, lon: -97.7431, timezone: 'America/Chicago', activities: inlandUS(['stand_up_paddleboarding']), description: 'Lady Bird Lake runs through downtown — SUP from the centre, hill-country gravel an hour west.' },
+  { slug: 'jacksonville', name: 'Jacksonville', region: 'Florida', country: 'United States', lat: 30.3322, lon: -81.6557, timezone: 'America/New_York', activities: coastalUS(), beachFacingDeg: 75, description: 'The biggest US city by land area — Atlantic beach on one side, the St. Johns River through the middle.' },
+  { slug: 'fort-worth', name: 'Fort Worth', region: 'Texas', country: 'United States', lat: 32.7555, lon: -97.3308, timezone: 'America/Chicago', activities: inlandUS(), description: 'Dallas\' twin city, with its own outdoor culture rooted in the Trinity River and the Stockyards.' },
+  { slug: 'guadalajara', name: 'Guadalajara', region: 'Jalisco', country: 'Mexico', lat: 20.6597, lon: -103.3496, timezone: 'America/Mexico_City', activities: inlandEuropean(['rock_climbing']), description: 'Bosque La Primavera on its western edge — a 30,000-hectare forest with mountain biking trails and hot springs.' },
+  { slug: 'columbus-oh', name: 'Columbus', region: 'Ohio', country: 'United States', lat: 39.9612, lon: -82.9988, timezone: 'America/New_York', activities: inlandUS(['ice_skating', 'ice_hockey']), description: 'Flat, four-seasons, and built around the Olentangy and Scioto rivers.' },
+  { slug: 'charlotte', name: 'Charlotte', region: 'North Carolina', country: 'United States', lat: 35.2271, lon: -80.8431, timezone: 'America/New_York', activities: inlandUS(), description: 'In the Piedmont — between the Blue Ridge and the Atlantic, with both within day-trip range.' },
+  { slug: 'indianapolis', name: 'Indianapolis', region: 'Indiana', country: 'United States', lat: 39.7684, lon: -86.1581, timezone: 'America/New_York', activities: inlandUS(['ice_skating']), description: 'A capital city built around the White River and the Monon Trail.' },
+  { slug: 'san-francisco', name: 'San Francisco', region: 'California', country: 'United States', lat: 37.7749, lon: -122.4194, timezone: 'America/Los_Angeles', activities: coastalUS(), beachFacingDeg: 250, description: 'Microclimates that change in five minutes, year-round wetsuit-only sea swimming, and Marin Headlands on the doorstep.' },
+  { slug: 'seattle', name: 'Seattle', region: 'Washington', country: 'United States', lat: 47.6062, lon: -122.3321, timezone: 'America/Los_Angeles', activities: coastalUS([...WINTER_SPORTS]), description: 'Puget Sound on one side, the Cascades on the other — and famously moody weather.' },
+  { slug: 'denver', name: 'Denver', region: 'Colorado', country: 'United States', lat: 39.7392, lon: -104.9903, timezone: 'America/Denver', activities: alpineCity(), description: 'A mile high, with the Front Range 30 minutes west and 300 days of sun a year.' },
+  { slug: 'monterrey', name: 'Monterrey', region: 'Nuevo León', country: 'Mexico', lat: 25.6866, lon: -100.3161, timezone: 'America/Monterrey', activities: alpineCity(['rock_climbing']), description: 'Surrounded by the Sierra Madre — Mexico\'s climbing capital, with Potrero Chico an hour north.' },
+  { slug: 'washington-dc', name: 'Washington D.C.', region: 'District of Columbia', country: 'United States', lat: 38.9072, lon: -77.0369, timezone: 'America/New_York', activities: inlandUS(), description: 'The Potomac runs through it, and Rock Creek Park is 1,750 acres of woods inside the city.' },
+  { slug: 'boston', name: 'Boston', region: 'Massachusetts', country: 'United States', lat: 42.3601, lon: -71.0589, timezone: 'America/New_York', activities: coastalUS([...WINTER_SPORTS]), description: 'On Massachusetts Bay, with a strong harbour culture and a four-seasons climate.' },
+  { slug: 'montreal', name: 'Montreal', region: 'Quebec', country: 'Canada', lat: 45.5017, lon: -73.5673, timezone: 'America/Toronto', activities: inlandEuropean([...WINTER_SPORTS, 'ice_hockey', 'ice_skating']), description: 'An island city with Mont Royal in the middle and the Laurentians an hour north.' },
+  { slug: 'el-paso', name: 'El Paso', region: 'Texas', country: 'United States', lat: 31.7619, lon: -106.4850, timezone: 'America/Denver', activities: inlandUS(), description: 'Franklin Mountains run through it — high desert with cool nights and an 80km radius of outdoor terrain.' },
+  { slug: 'nashville', name: 'Nashville', region: 'Tennessee', country: 'United States', lat: 36.1627, lon: -86.7816, timezone: 'America/Chicago', activities: inlandUS(['fly_fishing_freshwater']), description: 'The Cumberland River through the middle and Percy Warner Park within the city limits.' },
+  { slug: 'detroit', name: 'Detroit', region: 'Michigan', country: 'United States', lat: 42.3314, lon: -83.0458, timezone: 'America/Detroit', activities: inlandUS(['ice_hockey', 'ice_skating']), description: 'On the Detroit River, with Belle Isle Park in the middle and Lake St. Clair to the east.' },
+  { slug: 'oklahoma-city', name: 'Oklahoma City', region: 'Oklahoma', country: 'United States', lat: 35.4676, lon: -97.5164, timezone: 'America/Chicago', activities: inlandUS(), description: 'Flat plains city — proper summer storms, surprisingly mild winters, big-sky stargazing on the outskirts.' },
+  { slug: 'las-vegas', name: 'Las Vegas', region: 'Nevada', country: 'United States', lat: 36.1716, lon: -115.1391, timezone: 'America/Los_Angeles', activities: inlandUS(['rock_climbing']), description: 'Red Rock Canyon 20 minutes west — a desert climbing and hiking landscape on the edge of the strip.' },
+  { slug: 'portland-or', name: 'Portland', region: 'Oregon', country: 'United States', lat: 45.5152, lon: -122.6784, timezone: 'America/Los_Angeles', activities: coastalUS(['skiing', 'snowboarding']), description: 'Forty minutes from Mount Hood, two hours from the Oregon coast, and rain that defines the local outdoor culture.' },
+  { slug: 'memphis', name: 'Memphis', region: 'Tennessee', country: 'United States', lat: 35.1495, lon: -90.0490, timezone: 'America/Chicago', activities: inlandUS(['fly_fishing_freshwater']), description: 'On the Mississippi, with Shelby Farms — five times the size of Central Park — inside the city limits.' },
+  { slug: 'louisville', name: 'Louisville', region: 'Kentucky', country: 'United States', lat: 38.2527, lon: -85.7585, timezone: 'America/New_York', activities: inlandUS(), description: 'On the Ohio River, with the Bluegrass region of horse country immediately south.' },
+  { slug: 'baltimore', name: 'Baltimore', region: 'Maryland', country: 'United States', lat: 39.2904, lon: -76.6122, timezone: 'America/New_York', activities: coastalUS(), description: 'On Chesapeake Bay — sailing, blue crab, and an Inner Harbor culture that goes back to the 18th century.' },
+  { slug: 'milwaukee', name: 'Milwaukee', region: 'Wisconsin', country: 'United States', lat: 43.0389, lon: -87.9065, timezone: 'America/Chicago', activities: coastalUS([...WINTER_SPORTS]).filter((a) => a !== 'surfing'), description: 'On Lake Michigan\'s western shore — hard winters, beach summers, and a long list of outdoor festivals.' },
+  { slug: 'albuquerque', name: 'Albuquerque', region: 'New Mexico', country: 'United States', lat: 35.0844, lon: -106.6504, timezone: 'America/Denver', activities: alpineCity(), description: 'In the high desert with the Sandia Mountains directly east — a 3,000-metre summit reachable by tram.' },
+  { slug: 'tucson', name: 'Tucson', region: 'Arizona', country: 'United States', lat: 32.2226, lon: -110.9747, timezone: 'America/Phoenix', activities: alpineCity(['rock_climbing']).filter((a) => a !== 'cross_country_skiing'), description: 'Sky islands — five mountain ranges visible from town, each with its own climate band.' },
+  { slug: 'fresno', name: 'Fresno', region: 'California', country: 'United States', lat: 36.7378, lon: -119.7871, timezone: 'America/Los_Angeles', activities: alpineCity(), description: 'Yosemite, Sequoia and Kings Canyon all within 90 minutes — California\'s outdoor capital by some measures.' },
+  { slug: 'sacramento', name: 'Sacramento', region: 'California', country: 'United States', lat: 38.5816, lon: -121.4944, timezone: 'America/Los_Angeles', activities: inlandUS(['kayaking', 'fly_fishing_freshwater']), description: 'Where the Sacramento and American rivers meet — a paddling capital, and an hour from the Sierra Nevada.' },
+  { slug: 'kansas-city', name: 'Kansas City', region: 'Missouri', country: 'United States', lat: 39.0997, lon: -94.5786, timezone: 'America/Chicago', activities: inlandUS(), description: 'A four-seasons river city with more fountains per capita than anywhere outside Rome.' },
+  { slug: 'mesa', name: 'Mesa', region: 'Arizona', country: 'United States', lat: 33.4152, lon: -111.8315, timezone: 'America/Phoenix', activities: inlandUS(['rock_climbing']), description: 'Tonto National Forest on its eastern edge — desert climbing, paddling on Saguaro Lake, and a long shoulder season.' },
+  { slug: 'atlanta', name: 'Atlanta', region: 'Georgia', country: 'United States', lat: 33.7490, lon: -84.3880, timezone: 'America/New_York', activities: inlandUS(), description: 'A wooded city in the southern Appalachian foothills, with the BeltLine doing more for outdoor culture than any city plan in recent memory.' },
+  { slug: 'omaha', name: 'Omaha', region: 'Nebraska', country: 'United States', lat: 41.2565, lon: -95.9345, timezone: 'America/Chicago', activities: inlandUS(['ice_skating']), description: 'On the Missouri River, with proper Great Plains winters and big-sky summer storms.' },
+  { slug: 'colorado-springs', name: 'Colorado Springs', region: 'Colorado', country: 'United States', lat: 38.8339, lon: -104.8214, timezone: 'America/Denver', activities: alpineCity(['rock_climbing']), description: 'At the foot of Pikes Peak — 6,000 feet up, 300 days of sun, and trail access from almost every neighbourhood.' },
+  { slug: 'miami', name: 'Miami', region: 'Florida', country: 'United States', lat: 25.7617, lon: -80.1918, timezone: 'America/New_York', activities: coastalUS(), beachFacingDeg: 85, description: 'Subtropical, Atlantic on one flank, Biscayne Bay on the other — and the closest US city to the Bahamas reefs.' },
+  { slug: 'vancouver', name: 'Vancouver', region: 'British Columbia', country: 'Canada', lat: 49.2827, lon: -123.1207, timezone: 'America/Vancouver', activities: coastalUS([...WINTER_SPORTS]), description: 'Where the Pacific meets the Coast Mountains — ski in the morning, sail in the afternoon, year-round.' },
+  { slug: 'calgary', name: 'Calgary', region: 'Alberta', country: 'Canada', lat: 51.0447, lon: -114.0719, timezone: 'America/Edmonton', activities: alpineCity(['fly_fishing_freshwater']), description: 'The eastern gateway to the Canadian Rockies — Banff is 90 minutes west, Bow River runs through the city.' },
+  { slug: 'minneapolis', name: 'Minneapolis', region: 'Minnesota', country: 'United States', lat: 44.9778, lon: -93.2650, timezone: 'America/Chicago', activities: inlandUS([...WINTER_SPORTS, 'sailing_inland']), description: 'Twenty lakes inside the city, the Mississippi through the middle, and a winter cycling culture that puts most cities to shame.' },
+  { slug: 'ottawa', name: 'Ottawa', region: 'Ontario', country: 'Canada', lat: 45.4215, lon: -75.6972, timezone: 'America/Toronto', activities: inlandUS([...WINTER_SPORTS, 'sailing_inland']), description: 'On the Ottawa River with Gatineau Park across it — the Rideau Canal becomes the world\'s longest skating rink every winter.' },
+];
+
+/**
+ * Lookup helper — returns the location for a given slug, or undefined.
+ */
+export function getLocationBySlug(slug: string): SeoLocation | undefined {
+  return SEO_LOCATIONS.find((l) => l.slug === slug);
+}
+
+/**
+ * Returns every (activity, location) pair that should have a generated page.
+ * Used by getStaticPaths and by the sitemap generator.
+ */
+export function getAllSeoPagePaths(): Array<{ activity: string; location: string }> {
+  const paths: Array<{ activity: string; location: string }> = [];
+  for (const loc of SEO_LOCATIONS) {
+    for (const activity of loc.activities) {
+      paths.push({ activity, location: loc.slug });
+    }
+  }
+  return paths;
+}
+
+/**
+ * Returns the count of pages this dataset would generate — for sanity checks.
+ */
+export function getSeoPageCount(): { locations: number; pages: number } {
+  return {
+    locations: SEO_LOCATIONS.length,
+    pages: SEO_LOCATIONS.reduce((acc, loc) => acc + loc.activities.length, 0),
+  };
+}
+
+/**
+ * Returns the list of locations that include a given activity. Used by the
+ * "Other good places for X" related-locations section on each page.
+ */
+export function getLocationsForActivity(activityId: string): SeoLocation[] {
+  return SEO_LOCATIONS.filter((l) => l.activities.includes(activityId));
+}

--- a/lib/seo/getActivityScore.ts
+++ b/lib/seo/getActivityScore.ts
@@ -20,6 +20,7 @@
  */
 
 import { getSuggestionsByDay } from '../../utils/getSuggestionsByDay';
+import type { Suggestion, WeatherData } from '../../utils/getSuggestionsByDay';
 import { activityTypes } from '../../data/activityTypes';
 import type { SeoLocation } from '../../data/seoLocations';
 
@@ -92,8 +93,9 @@ export async function getActivityScoreForLocation(
   });
 
   // 4. Pull out the score for this activity on each day
-  const weeklyOutlook: DailyScore[] = dailySuggestions.map((day: any, i: number) => {
-    const suggestion = day.suggestions?.find?.((s: any) => s.activityId === activityId);
+  const weeklyOutlook: DailyScore[] = dailySuggestions.map(
+    (day: { date: number; suggestions: Suggestion[] }, i: number) => {
+    const suggestion = day.suggestions?.find?.((s: Suggestion) => s.activityId === activityId);
     const score = suggestion?.score ?? 0;
     return {
       date: new Date(day.date * 1000).toISOString().slice(0, 10),
@@ -160,7 +162,7 @@ function labelForOffset(offset: number): string {
  */
 async function fetchWeatherForLocation(
   location: SeoLocation
-): Promise<Array<{ date: number; weather: any }>> {
+): Promise<Array<{ date: number; weather: WeatherData }>> {
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL_GODAISY || 'https://godaisy.io';
 
@@ -182,8 +184,11 @@ async function fetchWeatherForLocation(
     // Map the OWM response into the shape getSuggestionsByDay wants.
     // The exact key names below will depend on what your getFullWeather()
     // returns. Verify by logging `data` once and adjust the mapping.
+    type OWMDaily = { dt?: number; temp?: { day?: number }; rain?: number; wind_speed?: number; clouds?: number; humidity?: number };
+    type OWMHourly = { dt?: number; temp?: number; rain?: { '1h'?: number }; wind_speed?: number; clouds?: number; humidity?: number };
+
     if (Array.isArray(data?.daily)) {
-      return data.daily.slice(0, 7).map((d: any) => ({
+      return data.daily.slice(0, 7).map((d: OWMDaily) => ({
         date: d.dt ?? Math.floor(Date.now() / 1000),
         weather: {
           temperature: d.temp?.day,
@@ -197,7 +202,7 @@ async function fetchWeatherForLocation(
 
     // Fallback: try hourly[0..6] as daily proxies
     if (Array.isArray(data?.hourly)) {
-      return data.hourly.slice(0, 7).map((h: any) => ({
+      return data.hourly.slice(0, 7).map((h: OWMHourly) => ({
         date: h.dt ?? Math.floor(Date.now() / 1000),
         weather: {
           temperature: h.temp,

--- a/lib/seo/getActivityScore.ts
+++ b/lib/seo/getActivityScore.ts
@@ -1,0 +1,217 @@
+/**
+ * SEO page data fetcher.
+ *
+ * Wraps the existing Go Daisy scoring engine so the programmatic SEO pages
+ * (at /[activity]/[location-slug]) get the same scores the app produces.
+ *
+ * Called from `getStaticProps` in `pages/[activity]/[location].tsx`.
+ *
+ * Pattern:
+ *   1. Fetch weather data for a location from the upstream services
+ *   2. Map it into the shape getSuggestionsByDay expects
+ *   3. Run the scoring engine for the chosen activity
+ *   4. Return a clean, page-ready payload
+ *
+ * Currently the implementation uses a thin direct fetch of OpenWeather +
+ * Stormglass. Once you have time, swap the body of `fetchWeatherForLocation`
+ * to import and call `getFullWeather` from `lib/services/weatherService.ts`
+ * directly — that's the same function `/api/owm.ts` uses, and it'll keep
+ * scoring on the SEO pages and inside the app perfectly in sync.
+ */
+
+import { getSuggestionsByDay } from '../../utils/getSuggestionsByDay';
+import { activityTypes } from '../../data/activityTypes';
+import type { SeoLocation } from '../../data/seoLocations';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface DailyScore {
+  date: string; // ISO date (YYYY-MM-DD)
+  dayLabel: string; // "Today", "Tomorrow", "Friday"...
+  score: number; // 0–100
+  evaluation: 'perfect' | 'good' | 'fair' | 'poor' | 'indoor' | 'indoorAlternative';
+  reasoning: string;
+}
+
+export interface ActivityScorePayload {
+  // Current-day answer
+  todayScore: number;
+  todayEvaluation: DailyScore['evaluation'];
+  todayReasoning: string;
+  // Best window in next 7 days
+  bestDay: DailyScore | null;
+  // Full 7-day outlook for the chart
+  weeklyOutlook: DailyScore[];
+  // Headline weather facts shown in the "Why this score?" section
+  conditionsToday: {
+    temperatureC?: number;
+    feelsLikeC?: number;
+    windSpeedKmh?: number;
+    windDirection?: string;
+    precipitationMm?: number;
+    cloudCoverPct?: number;
+    uvIndex?: number;
+    waveHeightM?: number;
+    swellPeriodS?: number;
+    seaTempC?: number;
+    nextHighTide?: string;
+    nextLowTide?: string;
+  };
+  // When the data was last refreshed (used for "Last updated" footer)
+  lastUpdated: string;
+  // Whether we used cached/fallback data (so the page can show a notice)
+  isStale: boolean;
+}
+
+// ============================================================================
+// Main entry — called from getStaticProps
+// ============================================================================
+
+export async function getActivityScoreForLocation(
+  activityId: string,
+  location: SeoLocation
+): Promise<ActivityScorePayload | null> {
+  // 1. Find the activity definition
+  const activity = activityTypes.find((a) => a.id === activityId);
+  if (!activity) return null;
+
+  // 2. Fetch weather for the next 7 days
+  const forecast = await fetchWeatherForLocation(location);
+  if (!forecast || forecast.length === 0) return null;
+
+  // 3. Run the scoring engine for this single activity
+  const now = new Date();
+  const dailySuggestions = getSuggestionsByDay({
+    forecast,
+    activities: [activity],
+    interests: [activityId],
+    now,
+    includeAllActivities: true, // we want a score even on "poor" days
+  });
+
+  // 4. Pull out the score for this activity on each day
+  const weeklyOutlook: DailyScore[] = dailySuggestions.map((day: any, i: number) => {
+    const suggestion = day.suggestions?.find?.((s: any) => s.activityId === activityId);
+    const score = suggestion?.score ?? 0;
+    return {
+      date: new Date(day.date * 1000).toISOString().slice(0, 10),
+      dayLabel: labelForOffset(i),
+      score,
+      evaluation: suggestion?.evaluation ?? 'poor',
+      reasoning: suggestion?.reasoning ?? '',
+    };
+  });
+
+  const todayDay = weeklyOutlook[0];
+  const bestDay = [...weeklyOutlook]
+    .filter((d) => d.score > 0)
+    .sort((a, b) => b.score - a.score)[0] ?? null;
+
+  // 5. Pull today's headline conditions for the "Why this score?" section
+  const todayWeather = forecast[0]?.weather ?? {};
+  const conditionsToday: ActivityScorePayload['conditionsToday'] = {
+    temperatureC: todayWeather.temperature,
+    windSpeedKmh: todayWeather.windspeed,
+    precipitationMm: todayWeather.precipitation,
+    cloudCoverPct: todayWeather.clouds,
+    waveHeightM: todayWeather.waveHeight,
+    swellPeriodS: todayWeather.swellPeriod,
+    seaTempC: todayWeather.waterTemperature,
+  };
+
+  return {
+    todayScore: todayDay?.score ?? 0,
+    todayEvaluation: todayDay?.evaluation ?? 'poor',
+    todayReasoning: todayDay?.reasoning ?? '',
+    bestDay,
+    weeklyOutlook,
+    conditionsToday,
+    lastUpdated: now.toISOString(),
+    isStale: false,
+  };
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function labelForOffset(offset: number): string {
+  if (offset === 0) return 'Today';
+  if (offset === 1) return 'Tomorrow';
+  const d = new Date();
+  d.setDate(d.getDate() + offset);
+  return d.toLocaleDateString('en-GB', { weekday: 'long' });
+}
+
+/**
+ * Fetch weather for a location and return it in the shape getSuggestionsByDay
+ * expects: `Array<{ date: number; weather: WeatherData }>`.
+ *
+ * TODO (low effort, high value): replace this body with a direct import of
+ * `getFullWeather` from `../../lib/services/weatherService.ts`. That keeps
+ * scoring on these SEO pages perfectly in sync with what `/api/owm.ts`
+ * returns to the app.
+ *
+ * For now, this is a defensive stub that calls the existing /api/owm endpoint
+ * over HTTP. The internal HTTP call works fine on Vercel (the request stays
+ * inside the same edge region) but adds latency you don't strictly need.
+ */
+async function fetchWeatherForLocation(
+  location: SeoLocation
+): Promise<Array<{ date: number; weather: any }>> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL_GODAISY || 'https://godaisy.io';
+
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/owm?lat=${location.lat}&lon=${location.lon}&units=metric`,
+      { headers: { 'User-Agent': 'GoDaisy-SEO-Build/1.0' } }
+    );
+    if (!res.ok) {
+      console.error(
+        `Weather fetch failed for ${location.slug}:`,
+        res.status,
+        await res.text()
+      );
+      return [];
+    }
+    const data = await res.json();
+
+    // Map the OWM response into the shape getSuggestionsByDay wants.
+    // The exact key names below will depend on what your getFullWeather()
+    // returns. Verify by logging `data` once and adjust the mapping.
+    if (Array.isArray(data?.daily)) {
+      return data.daily.slice(0, 7).map((d: any) => ({
+        date: d.dt ?? Math.floor(Date.now() / 1000),
+        weather: {
+          temperature: d.temp?.day,
+          precipitation: d.rain ?? 0,
+          windspeed: (d.wind_speed ?? 0) * 3.6, // m/s → km/h
+          clouds: d.clouds,
+          humidity: d.humidity,
+        },
+      }));
+    }
+
+    // Fallback: try hourly[0..6] as daily proxies
+    if (Array.isArray(data?.hourly)) {
+      return data.hourly.slice(0, 7).map((h: any) => ({
+        date: h.dt ?? Math.floor(Date.now() / 1000),
+        weather: {
+          temperature: h.temp,
+          precipitation: h.rain?.['1h'] ?? 0,
+          windspeed: (h.wind_speed ?? 0) * 3.6,
+          clouds: h.clouds,
+          humidity: h.humidity,
+        },
+      }));
+    }
+
+    return [];
+  } catch (err) {
+    console.error(`Weather fetch error for ${location.slug}:`, err);
+    return [];
+  }
+}

--- a/pages/[activity]/[location].tsx
+++ b/pages/[activity]/[location].tsx
@@ -26,9 +26,7 @@ import type { GetStaticPaths, GetStaticProps } from 'next';
 import SEO from '../../components/SEO';
 import AppHeader from '../../components/AppHeader';
 import {
-  SEO_LOCATIONS,
   getLocationBySlug,
-  getAllSeoPagePaths,
   getLocationsForActivity,
   type SeoLocation,
 } from '../../data/seoLocations';

--- a/pages/[activity]/[location].tsx
+++ b/pages/[activity]/[location].tsx
@@ -1,0 +1,616 @@
+/**
+ * Programmatic SEO page — "Is today a good day for {activity} in {location}?"
+ *
+ * Dynamic route: /{activity-slug}/{location-slug}
+ *   e.g. /surfing/llanes-asturias
+ *        /padel/madrid
+ *        /stargazing/snowdonia-eryri
+ *
+ * ISR with fallback: 'blocking' — pages are generated on-demand on first
+ * request, cached at the edge, and rebuilt every hour. At ~2,500 pages this
+ * scales well without overloading deploy builds.
+ *
+ * Each page targets a real long-tail search query. The combination of fresh
+ * scoring data, location-specific copy, internal cross-links, and FAQPage +
+ * Place JSON-LD is what keeps these out of "doorway page" territory.
+ *
+ * Source of activity/location data: data/seoLocations.ts
+ * Source of scoring: lib/seo/getActivityScore.ts → utils/getSuggestionsByDay
+ */
+
+import React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import SEO from '../../components/SEO';
+import AppHeader from '../../components/AppHeader';
+import {
+  SEO_LOCATIONS,
+  getLocationBySlug,
+  getAllSeoPagePaths,
+  getLocationsForActivity,
+  type SeoLocation,
+} from '../../data/seoLocations';
+import {
+  getActivityScoreForLocation,
+  type ActivityScorePayload,
+} from '../../lib/seo/getActivityScore';
+import { activityTypes } from '../../data/activityTypes';
+import { getActivityEmoji } from '../../data/emojiMap';
+
+const Footer = dynamic(() => import('../../components/footer'), { ssr: false });
+
+// ============================================================================
+// Slug conversion: activity IDs use snake_case in the data layer, but URLs
+// use kebab-case for SEO and readability.
+// ============================================================================
+
+const activityIdToSlug = (id: string): string => id.replace(/_/g, '-');
+const slugToActivityId = (slug: string): string => slug.replace(/-/g, '_');
+
+// ============================================================================
+// Page props
+// ============================================================================
+
+interface PageProps {
+  activityId: string;
+  activitySlug: string;
+  activityName: string;
+  activityEmoji: string;
+  location: SeoLocation;
+  score: ActivityScorePayload;
+  relatedAtLocation: Array<{
+    activityId: string;
+    name: string;
+    emoji: string;
+    score: number;
+    url: string;
+  }>;
+  relatedLocations: Array<{
+    slug: string;
+    name: string;
+    region: string;
+    country: string;
+    score: number;
+    url: string;
+  }>;
+}
+
+// ============================================================================
+// Static paths
+// ============================================================================
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Pre-render zero pages at deploy — let ISR + fallback:'blocking' generate
+  // on first request. This keeps deploy times short even at ~2,500 pages.
+  // For a tighter pilot, return e.g. the top 50 paths here and Vercel will
+  // pre-render those at deploy, leaving the rest to ISR.
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+// ============================================================================
+// Static props (called per page, then cached and revalidated every hour)
+// ============================================================================
+
+export const getStaticProps: GetStaticProps<PageProps> = async (ctx) => {
+  const params = ctx.params as { activity?: string; location?: string };
+  const activitySlug = params.activity ?? '';
+  const locationSlug = params.location ?? '';
+  const activityId = slugToActivityId(activitySlug);
+
+  // 1. Validate location
+  const location = getLocationBySlug(locationSlug);
+  if (!location) return { notFound: true, revalidate: 3600 };
+
+  // 2. Validate that this activity is supported at this location
+  if (!location.activities.includes(activityId)) {
+    return { notFound: true, revalidate: 3600 };
+  }
+
+  // 3. Validate activity exists in the master activity list
+  const activity = activityTypes.find((a) => a.id === activityId);
+  if (!activity) return { notFound: true, revalidate: 3600 };
+
+  // 4. Fetch the score payload
+  const score = await getActivityScoreForLocation(activityId, location);
+  if (!score) {
+    // Don't bake a broken page — let ISR retry on the next request
+    return { notFound: true, revalidate: 60 };
+  }
+
+  // 5. Build the "related activities at this location" list (top 5 today)
+  const otherActivitiesHere = location.activities.filter(
+    (a) => a !== activityId
+  );
+  const otherScoresHere = await Promise.all(
+    otherActivitiesHere.slice(0, 8).map(async (a) => {
+      const p = await getActivityScoreForLocation(a, location);
+      return {
+        activityId: a,
+        name: prettyActivityName(a),
+        emoji: getActivityEmoji?.(a) ?? '•',
+        score: p?.todayScore ?? 0,
+        url: `/${activityIdToSlug(a)}/${location.slug}`,
+      };
+    })
+  );
+  const relatedAtLocation = otherScoresHere
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+
+  // 6. Build the "other good locations for this activity today" list (top 5)
+  const otherLocations = getLocationsForActivity(activityId).filter(
+    (l) => l.slug !== location.slug
+  );
+  const otherLocScores = await Promise.all(
+    otherLocations.slice(0, 10).map(async (l) => {
+      const p = await getActivityScoreForLocation(activityId, l);
+      return {
+        slug: l.slug,
+        name: l.name,
+        region: l.region,
+        country: l.country,
+        score: p?.todayScore ?? 0,
+        url: `/${activitySlug}/${l.slug}`,
+      };
+    })
+  );
+  const relatedLocations = otherLocScores
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+
+  return {
+    props: {
+      activityId,
+      activitySlug,
+      activityName: prettyActivityName(activityId),
+      activityEmoji: getActivityEmoji?.(activityId) ?? '•',
+      location,
+      score,
+      relatedAtLocation,
+      relatedLocations,
+    },
+    revalidate: 3600, // rebuild every hour
+  };
+};
+
+// ============================================================================
+// Display name helper (snake_case → human)
+// ============================================================================
+
+function prettyActivityName(id: string): string {
+  const overrides: Record<string, string> = {
+    football_soccer: 'football',
+    sea_kayaking: 'sea kayaking',
+    stand_up_paddleboarding: 'stand-up paddleboarding',
+    sup_sea: 'sea SUP',
+    sea_swimming: 'sea swimming',
+    wild_swimming: 'wild swimming',
+    rock_climbing: 'rock climbing',
+    indoor_climbing: 'indoor climbing',
+    mountain_biking: 'mountain biking',
+    road_cycling: 'road cycling',
+    gravel_biking: 'gravel cycling',
+    trail_running: 'trail running',
+    fly_fishing_freshwater: 'fly fishing',
+    sea_fishing_shore: 'shore sea fishing',
+    sea_fishing_boat: 'boat sea fishing',
+    coarse_fishing: 'coarse fishing',
+    ice_fishing: 'ice fishing',
+    cross_country_skiing: 'cross-country skiing',
+    ice_skating: 'ice skating',
+    ice_hockey: 'ice hockey',
+    ice_hockey_indoor: 'indoor ice hockey',
+    ice_hockey_us: 'ice hockey',
+    gaelic_football: 'Gaelic football',
+    hurling_camogie: 'hurling and camogie',
+    american_football: 'American football',
+    beach_volleyball: 'beach volleyball',
+    basketball_outdoor: 'outdoor basketball',
+    volleyball_indoor: 'indoor volleyball',
+    tennis_indoor: 'indoor tennis',
+    indoor_swimming: 'indoor swimming',
+    outdoor_yoga: 'outdoor yoga',
+    outdoor_meditation: 'outdoor meditation',
+    outdoor_painting: 'outdoor painting',
+    outdoor_music: 'outdoor music',
+    outdoor_chess: 'outdoor chess',
+    outdoor_reading: 'outdoor reading',
+    outdoor_gardening: 'gardening',
+    outdoor_playground: 'outdoor play',
+    outdoor_gym: 'outdoor gym',
+    urban_exploring: 'urban exploring',
+    going_to_pub: 'going to the pub',
+    table_tennis: 'table tennis',
+    playing_cards: 'card games',
+    watch_a_movie: 'film at home',
+    playing_records: 'listening to records',
+    make_music: 'making music',
+    jet_skiing: 'jet skiing',
+    rock_hopping: 'rock hopping',
+    martial_arts: 'martial arts',
+    tai_chi: 'tai chi',
+    mushroom_hunting: 'mushroom hunting',
+    sailing_inland: 'inland sailing',
+    windsurfing_inland: 'inland windsurfing',
+    riding_motorbike: 'motorbike riding',
+    gym_workout: 'gym workouts',
+  };
+  return overrides[id] ?? id.replace(/_/g, ' ');
+}
+
+// ============================================================================
+// Score → traffic-light helper
+// ============================================================================
+
+function scoreColor(score: number): { bg: string; text: string; label: string } {
+  if (score >= 80) return { bg: 'bg-success', text: 'text-success-content', label: 'Excellent' };
+  if (score >= 60) return { bg: 'bg-success/80', text: 'text-success-content', label: 'Good' };
+  if (score >= 40) return { bg: 'bg-warning', text: 'text-warning-content', label: 'Fair' };
+  return { bg: 'bg-error/80', text: 'text-error-content', label: 'Poor' };
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export default function ProgrammaticSeoPage({
+  activityId,
+  activityName,
+  activityEmoji,
+  location,
+  score,
+  relatedAtLocation,
+  relatedLocations,
+}: PageProps) {
+  const todayColor = scoreColor(score.todayScore);
+  const canonicalUrl = `https://godaisy.io/${activityIdToSlug(activityId)}/${location.slug}`;
+  const pageTitle = `Is today a good day for ${activityName} in ${location.name}?`;
+  const pageDescription = `${todayColor.label} day for ${activityName} in ${location.name} — ${score.todayScore}/100. Live weather scoring for ${location.name}, ${location.country}, updated hourly. Free, ad-free.`;
+
+  // ----- JSON-LD: FAQPage answers the literal search query -----
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: pageTitle,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: `Today is a ${todayColor.label.toLowerCase()} day for ${activityName} in ${location.name} — ${score.todayScore} out of 100. ${score.todayReasoning || ''} ${score.bestDay && score.bestDay.dayLabel !== 'Today' ? `The best day in the next week looks like ${score.bestDay.dayLabel} (${score.bestDay.score}/100).` : ''}`.trim(),
+        },
+      },
+    ],
+  };
+
+  // ----- JSON-LD: Place schema for the location -----
+  const placeJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Place',
+    name: location.name,
+    address: {
+      '@type': 'PostalAddress',
+      addressRegion: location.region,
+      addressCountry: location.country,
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: location.lat,
+      longitude: location.lon,
+    },
+  };
+
+  return (
+    <>
+      <SEO
+        title={pageTitle}
+        description={pageDescription}
+        url={canonicalUrl}
+      />
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(placeJsonLd) }}
+        />
+      </Head>
+
+      <AppHeader />
+
+      <main className="min-h-screen bg-base-100 text-base-content">
+        {/* ===================================================================
+            1. HERO — the literal search query, answered
+            =================================================================== */}
+        <section className="px-4 py-10 md:py-16 bg-gradient-to-b from-base-200 to-base-100">
+          <div className="max-w-4xl mx-auto">
+            <div className="text-sm text-base-content/60 mb-2">
+              <Link href="/" className="link">Go Daisy</Link>
+              {' › '}
+              <span className="capitalize">{activityName}</span>
+              {' › '}
+              <span>{location.name}, {location.country}</span>
+            </div>
+
+            <h1 className="text-3xl md:text-5xl font-bold leading-tight mb-6">
+              <span aria-hidden="true">{activityEmoji}</span> Is today a good day
+              for {activityName} in {location.name}?
+            </h1>
+
+            <div
+              className={`inline-flex items-center gap-3 px-5 py-3 rounded-full ${todayColor.bg} ${todayColor.text} mb-6`}
+            >
+              <span className="text-2xl md:text-3xl font-bold">
+                {score.todayScore}<span className="text-base font-normal opacity-80">/100</span>
+              </span>
+              <span className="text-lg font-medium">{todayColor.label}</span>
+            </div>
+
+            {score.todayReasoning && (
+              <p className="text-lg md:text-xl text-base-content/80 leading-relaxed max-w-3xl">
+                {score.todayReasoning}
+              </p>
+            )}
+
+            <div className="mt-6">
+              <Link href="/" className="btn btn-primary">
+                Open Go Daisy for the full forecast
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ===================================================================
+            2. 7-DAY OUTLOOK CHART (simple bar visualisation)
+            =================================================================== */}
+        <section className="px-4 py-10 bg-base-100">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl md:text-3xl font-bold mb-2">
+              7-day outlook for {activityName} in {location.name}
+            </h2>
+            {score.bestDay && (
+              <p className="text-base-content/70 mb-6">
+                Best day looks like <strong>{score.bestDay.dayLabel}</strong> at{' '}
+                {score.bestDay.score}/100.
+              </p>
+            )}
+
+            <div className="grid grid-cols-7 gap-2">
+              {score.weeklyOutlook.map((d) => {
+                const color = scoreColor(d.score);
+                const height = Math.max(d.score, 8);
+                return (
+                  <div key={d.date} className="flex flex-col items-center">
+                    <div className="h-32 w-full flex flex-col justify-end">
+                      <div
+                        className={`${color.bg} rounded-t w-full transition-all`}
+                        style={{ height: `${height}%` }}
+                        aria-label={`${d.dayLabel}: ${d.score} out of 100`}
+                      />
+                    </div>
+                    <div className="text-xs mt-2 text-base-content/70 truncate w-full text-center">
+                      {d.dayLabel.slice(0, 3)}
+                    </div>
+                    <div className="text-sm font-semibold">{d.score}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        {/* ===================================================================
+            3. WHY THIS SCORE — conditions table
+            =================================================================== */}
+        <section className="px-4 py-10 bg-base-200">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl md:text-3xl font-bold mb-6">
+              Why this score?
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {score.conditionsToday.temperatureC !== undefined && (
+                <ConditionCard label="Temperature" value={`${Math.round(score.conditionsToday.temperatureC)}°C`} />
+              )}
+              {score.conditionsToday.windSpeedKmh !== undefined && (
+                <ConditionCard label="Wind" value={`${Math.round(score.conditionsToday.windSpeedKmh)} km/h${score.conditionsToday.windDirection ? ` ${score.conditionsToday.windDirection}` : ''}`} />
+              )}
+              {score.conditionsToday.precipitationMm !== undefined && (
+                <ConditionCard label="Rainfall" value={`${score.conditionsToday.precipitationMm.toFixed(1)} mm`} />
+              )}
+              {score.conditionsToday.cloudCoverPct !== undefined && (
+                <ConditionCard label="Cloud cover" value={`${Math.round(score.conditionsToday.cloudCoverPct)}%`} />
+              )}
+              {score.conditionsToday.uvIndex !== undefined && (
+                <ConditionCard label="UV index" value={`${score.conditionsToday.uvIndex.toFixed(1)}`} />
+              )}
+              {score.conditionsToday.waveHeightM !== undefined && (
+                <ConditionCard label="Wave height" value={`${score.conditionsToday.waveHeightM.toFixed(1)} m`} />
+              )}
+              {score.conditionsToday.swellPeriodS !== undefined && (
+                <ConditionCard label="Swell period" value={`${Math.round(score.conditionsToday.swellPeriodS)} s`} />
+              )}
+              {score.conditionsToday.seaTempC !== undefined && (
+                <ConditionCard label="Sea temperature" value={`${Math.round(score.conditionsToday.seaTempC)}°C`} />
+              )}
+              {score.conditionsToday.nextHighTide && (
+                <ConditionCard label="Next high tide" value={score.conditionsToday.nextHighTide} />
+              )}
+              {score.conditionsToday.nextLowTide && (
+                <ConditionCard label="Next low tide" value={score.conditionsToday.nextLowTide} />
+              )}
+            </div>
+            <p className="mt-6 text-sm text-base-content/60">
+              Data from OpenWeather, Stormglass marine services and api.met.no.
+              Last updated{' '}
+              {new Date(score.lastUpdated).toLocaleTimeString('en-GB', {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}{' '}
+              UTC.
+            </p>
+          </div>
+        </section>
+
+        {/* ===================================================================
+            4. LOCATION CONTEXT
+            =================================================================== */}
+        <section className="px-4 py-10 bg-base-100">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl md:text-3xl font-bold mb-4">
+              About {activityName} in {location.name}
+            </h2>
+            {location.description && (
+              <p className="text-lg text-base-content/80 leading-relaxed mb-4">
+                {location.description}
+              </p>
+            )}
+            <p className="text-base-content/70">
+              Go Daisy scores {location.activities.length} activities for{' '}
+              {location.name}, including{' '}
+              {location.activities
+                .filter((a) => a !== activityId)
+                .slice(0, 5)
+                .map(prettyActivityName)
+                .join(', ')}
+              . The score for {activityName} updates hourly from the same
+              weather data professional services use.
+            </p>
+          </div>
+        </section>
+
+        {/* ===================================================================
+            5. RELATED ACTIVITIES AT THIS LOCATION
+            =================================================================== */}
+        {relatedAtLocation.length > 0 && (
+          <section className="px-4 py-10 bg-base-200">
+            <div className="max-w-4xl mx-auto">
+              <h2 className="text-2xl md:text-3xl font-bold mb-6">
+                Also today in {location.name}
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {relatedAtLocation.map((r) => {
+                  const c = scoreColor(r.score);
+                  return (
+                    <Link
+                      key={r.activityId}
+                      href={r.url}
+                      className="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+                    >
+                      <div className="card-body p-4 flex flex-row items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <span className="text-2xl" aria-hidden="true">{r.emoji}</span>
+                          <span className="font-medium capitalize">{r.name}</span>
+                        </div>
+                        <span
+                          className={`inline-flex items-center justify-center w-12 h-12 rounded-full ${c.bg} ${c.text} font-bold`}
+                        >
+                          {r.score}
+                        </span>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ===================================================================
+            6. RELATED LOCATIONS FOR THIS ACTIVITY
+            =================================================================== */}
+        {relatedLocations.length > 0 && (
+          <section className="px-4 py-10 bg-base-100">
+            <div className="max-w-4xl mx-auto">
+              <h2 className="text-2xl md:text-3xl font-bold mb-6">
+                Other good places for {activityName} today
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {relatedLocations.map((r) => {
+                  const c = scoreColor(r.score);
+                  return (
+                    <Link
+                      key={r.slug}
+                      href={r.url}
+                      className="card bg-base-200 shadow-sm hover:shadow-md transition-shadow"
+                    >
+                      <div className="card-body p-4 flex flex-row items-center justify-between">
+                        <div>
+                          <div className="font-medium">{r.name}</div>
+                          <div className="text-xs text-base-content/60">
+                            {r.region}, {r.country}
+                          </div>
+                        </div>
+                        <span
+                          className={`inline-flex items-center justify-center w-12 h-12 rounded-full ${c.bg} ${c.text} font-bold`}
+                        >
+                          {r.score}
+                        </span>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ===================================================================
+            FINAL CTA + FOOTER STRIP
+            =================================================================== */}
+        <section className="px-4 py-14 bg-gradient-to-b from-base-100 to-base-200">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-2xl md:text-3xl font-bold mb-4">
+              See {activityName} scored for every hour, every day, for your spot
+            </h2>
+            <p className="text-base-content/80 mb-6 max-w-2xl mx-auto">
+              Go Daisy is a free weather app that scores 100+ activities — set
+              your home location, pick the ones you do, and we&rsquo;ll tell you
+              when each is on.
+            </p>
+            <Link href="/" className="btn btn-primary btn-lg">
+              Open Go Daisy — free
+            </Link>
+          </div>
+        </section>
+
+        <section className="px-4 py-8 bg-base-200 border-t border-base-300">
+          <div className="max-w-4xl mx-auto text-center text-sm text-base-content/70">
+            <p className="mb-2">
+              Score for {activityName} in {location.name} updated hourly.
+              Free, ad-free. Built by independent makers in the UK and Asturias, Spain.
+            </p>
+            <p>
+              Weather data from OpenWeather, Stormglass and api.met.no.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}
+
+// ============================================================================
+// Small presentational helper for the conditions table
+// ============================================================================
+
+function ConditionCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="card bg-base-100 shadow-sm">
+      <div className="card-body p-4">
+        <div className="text-xs uppercase tracking-wide text-base-content/60">
+          {label}
+        </div>
+        <div className="text-xl font-semibold mt-1">{value}</div>
+      </div>
+    </div>
+  );
+}

--- a/pages/activities.tsx
+++ b/pages/activities.tsx
@@ -1022,16 +1022,33 @@ export default function ActivitiesPage() {
   if (!hasMounted || isHydrating) {
     return (
       <>
+        {/* SEO tags must render in the loading state too, so Googlebot sees
+            them even when it snapshots before user data has loaded. */}
+        <SEO
+          title="Your activities — weather-scored for the next 7 days"
+          description="See which of your chosen activities — hiking, surfing, cycling, padel, stargazing, gardening and 100+ more — are best for each day this week. Free, ad-free, UK and Europe."
+          url="https://godaisy.io/activities"
+        />
         <AppHeader
           homeLocation={homeLocation as LocationLite | undefined}
           coastalLocation={coastalLocation as LocationLite | undefined}
           onOpenHomeDialog={() => { /* optional: open home dialog from activities if you have one */ }}
           onOpenCoastDialog={() => { /* optional: open coast dialog from activities if you have one */ }}
         />
-        <section className="flex items-center justify-center py-16">
-          <div className="flex items-center">
-            <span className="loading loading-dots loading-lg text-secondary" aria-hidden="true"></span>
-            <span className="ml-3 text-base-content/80">{loadingActivities}</span>
+        <section className="px-4 py-12">
+          <div className="max-w-4xl mx-auto text-center">
+            <h1 className="text-3xl md:text-4xl font-bold mb-3">
+              Your activities, weather-scored
+            </h1>
+            <p className="text-base-content/70 mb-8">
+              The next seven days of conditions for the activities you care
+              about — hiking, surfing, cycling, padel, stargazing, gardening
+              and 100+ more.
+            </p>
+            <div className="flex items-center justify-center">
+              <span className="loading loading-dots loading-lg text-secondary" aria-hidden="true"></span>
+              <span className="ml-3 text-base-content/80">{loadingActivities}</span>
+            </div>
           </div>
         </section>
         <BottomNav />

--- a/pages/android-testers.tsx
+++ b/pages/android-testers.tsx
@@ -1,0 +1,393 @@
+/**
+ * Go Daisy — Android tester signup page at /android-testers.
+ *
+ * Single-file form that lets anyone offer to be one of the twelve testers
+ * Google Play requires for closed-beta-to-production launch.
+ *
+ * On submit:
+ *   - Inserts a row directly into the `android_testers` Supabase table
+ *   - Uses the existing browser Supabase client (anon key)
+ *   - RLS policy on the table allows anonymous inserts but blocks reads,
+ *     so signups can be created from the browser but not enumerated
+ *
+ * Linked migration: supabase/migrations/20260514016_android_testers.sql
+ *
+ * What to do with new signups (manual for now):
+ *   - Check the table in the Supabase dashboard each day
+ *   - Add the tester's Google account email to the Play Console closed test
+ *   - Send the opt-in URL to the email they provided
+ */
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import AppHeader from '../components/AppHeader';
+import dynamic from 'next/dynamic';
+import SEO from '../components/SEO';
+import { supabase } from '../lib/supabase/client';
+
+const Footer = dynamic(() => import('../components/footer'), { ssr: false });
+
+// ============================================================================
+// Activity options for the dropdown — mirrors the top-level taxonomy users
+// pick from on the home page. Keeps the form short while still capturing
+// the signal that helps us prioritise which sister apps to ship on Android.
+// ============================================================================
+
+const PRIMARY_ACTIVITIES = [
+  '— pick one (optional) —',
+  'Hiking / walking',
+  'Surfing / water sports',
+  'Cycling / mountain biking',
+  'Team sports (football, cricket, rugby, GAA)',
+  'Padel / tennis / racquet sports',
+  'Wild swimming / sea swimming',
+  'Stargazing / astronomy',
+  'Fishing (sea or freshwater)',
+  'Gardening',
+  'Winter sports (skiing, snowboarding)',
+  'Yoga / pilates / fitness',
+  'Indoor / social (pub, cinema, museums)',
+  'Something else',
+];
+
+// ============================================================================
+// Country options — common European markets first, then "other".
+// Used to spread testers across timezones, which Google Play seems to
+// reward for "real testing" signal.
+// ============================================================================
+
+const COUNTRIES = [
+  '— pick one (optional) —',
+  'United Kingdom',
+  'Ireland',
+  'Spain',
+  'Portugal',
+  'France',
+  'Italy',
+  'Germany',
+  'Netherlands',
+  'Poland',
+  'Sweden',
+  'Turkey',
+  'Other',
+];
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export default function AndroidTestersPage() {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [country, setCountry] = useState(COUNTRIES[0]);
+  const [activity, setActivity] = useState(PRIMARY_ACTIVITIES[0]);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!email.trim() || !email.includes('@')) {
+      setErrorMsg('Please enter a valid email address.');
+      setStatus('error');
+      return;
+    }
+
+    setStatus('loading');
+    setErrorMsg('');
+
+    const { error } = await supabase.from('android_testers').insert({
+      email: email.trim().toLowerCase(),
+      name: name.trim() || null,
+      country: country === COUNTRIES[0] ? null : country,
+      primary_activity:
+        activity === PRIMARY_ACTIVITIES[0] ? null : activity,
+    });
+
+    if (error) {
+      // If a duplicate email exists, treat it as success — the person already
+      // signed up. Otherwise show a generic error and ask them to email us.
+      if (error.code === '23505') {
+        setStatus('success');
+      } else {
+        console.error('android_testers insert error:', error);
+        setErrorMsg(
+          'Something went wrong. Please email hello@godaisy.io and we will add you manually.'
+        );
+        setStatus('error');
+      }
+      return;
+    }
+
+    setStatus('success');
+  }
+
+  return (
+    <>
+      <SEO
+        title="Help us launch Go Daisy on Android — be one of our 12 testers"
+        description="The Android version of Go Daisy is built and in closed beta. Google Play needs 12 testers to use the app for two weeks before we can launch. Sign up to be one of them and get free lifetime access to our specialist sister apps."
+        url="https://godaisy.io/android-testers"
+      />
+
+      <AppHeader />
+
+      <main className="min-h-screen bg-base-100 text-base-content">
+        <section className="px-4 py-12 md:py-20 bg-gradient-to-b from-base-200 to-base-100">
+          <div className="max-w-2xl mx-auto text-center">
+            <div className="text-5xl mb-4" aria-hidden="true">
+              🤖
+            </div>
+            <h1 className="text-3xl md:text-5xl font-bold mb-6">
+              Help us launch Go Daisy on Android.
+            </h1>
+            <p className="text-lg text-base-content/80 leading-relaxed">
+              The Android version is built and ready. Google Play asks us to
+              find twelve testers to use it on real Android phones for two
+              weeks before we can release it to the world — so that&rsquo;s
+              what we&rsquo;re doing.
+            </p>
+          </div>
+        </section>
+
+        <section className="px-4 py-10">
+          <div className="max-w-2xl mx-auto">
+            <div className="card bg-base-100 shadow-xl border border-base-300">
+              <div className="card-body">
+                {status === 'success' ? (
+                  <SuccessPanel />
+                ) : (
+                  <>
+                    <h2 className="card-title text-2xl mb-2">
+                      Sign me up
+                    </h2>
+                    <p className="text-base-content/70 mb-6">
+                      Takes 30 seconds. We&rsquo;ll email you the Google Play
+                      opt-in link within 24 hours.
+                    </p>
+
+                    <form onSubmit={handleSubmit} className="space-y-5">
+                      <div>
+                        <label className="label" htmlFor="email">
+                          <span className="label-text font-medium">
+                            Email <span className="text-error">*</span>
+                          </span>
+                          <span className="label-text-alt text-base-content/50">
+                            Use the email tied to your Google account on your
+                            Android phone
+                          </span>
+                        </label>
+                        <input
+                          id="email"
+                          type="email"
+                          required
+                          value={email}
+                          onChange={(e) => setEmail(e.target.value)}
+                          className="input input-bordered w-full"
+                          placeholder="you@example.com"
+                          autoComplete="email"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="label" htmlFor="name">
+                          <span className="label-text font-medium">
+                            First name
+                          </span>
+                          <span className="label-text-alt text-base-content/50">
+                            optional — so we can say hi
+                          </span>
+                        </label>
+                        <input
+                          id="name"
+                          type="text"
+                          value={name}
+                          onChange={(e) => setName(e.target.value)}
+                          className="input input-bordered w-full"
+                          placeholder="Alex"
+                          autoComplete="given-name"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="label" htmlFor="country">
+                          <span className="label-text font-medium">
+                            Country
+                          </span>
+                          <span className="label-text-alt text-base-content/50">
+                            optional
+                          </span>
+                        </label>
+                        <select
+                          id="country"
+                          value={country}
+                          onChange={(e) => setCountry(e.target.value)}
+                          className="select select-bordered w-full"
+                        >
+                          {COUNTRIES.map((c) => (
+                            <option key={c} value={c}>
+                              {c}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div>
+                        <label className="label" htmlFor="activity">
+                          <span className="label-text font-medium">
+                            What&rsquo;s your main thing?
+                          </span>
+                          <span className="label-text-alt text-base-content/50">
+                            optional
+                          </span>
+                        </label>
+                        <select
+                          id="activity"
+                          value={activity}
+                          onChange={(e) => setActivity(e.target.value)}
+                          className="select select-bordered w-full"
+                        >
+                          {PRIMARY_ACTIVITIES.map((a) => (
+                            <option key={a} value={a}>
+                              {a}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      {status === 'error' && (
+                        <div role="alert" className="alert alert-error">
+                          <span>{errorMsg}</span>
+                        </div>
+                      )}
+
+                      <button
+                        type="submit"
+                        disabled={status === 'loading'}
+                        className="btn btn-primary btn-lg w-full"
+                      >
+                        {status === 'loading'
+                          ? 'Signing you up...'
+                          : 'Sign me up as a tester'}
+                      </button>
+
+                      <p className="text-xs text-base-content/60 text-center">
+                        We&rsquo;ll only use your email to send you the
+                        closed-test opt-in link and one or two check-ins during
+                        the two-week test. No marketing.
+                      </p>
+                    </form>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {/* What you get block */}
+            <div className="mt-10">
+              <h2 className="text-2xl font-bold mb-4">What you get</h2>
+              <ul className="space-y-3 text-base-content/80">
+                <li className="flex gap-3">
+                  <span className="text-success text-xl">✓</span>
+                  <span>
+                    <strong>Early access to Go Daisy on Android</strong>{' '}
+                    before anyone else.
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-success text-xl">✓</span>
+                  <span>
+                    <strong>Free lifetime access</strong> to our specialist
+                    sister apps (Findr for sea anglers, Rise Daisy for fly
+                    fishers, Grow Daisy for gardeners) when they ship on
+                    Android.
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-success text-xl">✓</span>
+                  <span>
+                    <strong>A direct line to us</strong> for feedback — what
+                    works, what doesn&rsquo;t, what&rsquo;s missing.
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-success text-xl">✓</span>
+                  <span>
+                    <strong>Our genuine gratitude.</strong> You&rsquo;re the
+                    reason this app gets to launch.
+                  </span>
+                </li>
+              </ul>
+            </div>
+
+            {/* How it works */}
+            <div className="mt-10">
+              <h2 className="text-2xl font-bold mb-4">How the testing works</h2>
+              <ol className="space-y-3 text-base-content/80 list-decimal list-inside">
+                <li>
+                  You sign up (above). We email you the Google Play closed-test
+                  opt-in link within 24 hours.
+                </li>
+                <li>
+                  You click the link from your Android phone. Google Play
+                  installs Go Daisy for you.
+                </li>
+                <li>
+                  You use the app a few times a week, like a normal app. Set a
+                  home location, pick a few activities you actually do.
+                </li>
+                <li>
+                  Two weeks later (Google&rsquo;s requirement) we submit Go
+                  Daisy for production review. About a week after that, it&rsquo;s
+                  live on Google Play.
+                </li>
+                <li>
+                  You get a thank-you and your codes for free lifetime access
+                  to the sister apps.
+                </li>
+              </ol>
+              <p className="mt-4 text-sm text-base-content/60">
+                Total of about 10 minutes a week. No bug-hunting expected,
+                though feedback is very welcome.
+              </p>
+            </div>
+
+            <div className="mt-10 text-center">
+              <Link href="/" className="link link-primary">
+                &larr; Back to Go Daisy
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}
+
+// ============================================================================
+// Success panel — shown after a successful insert
+// ============================================================================
+
+function SuccessPanel() {
+  return (
+    <div className="text-center py-6">
+      <div className="text-6xl mb-4" aria-hidden="true">
+        🎉
+      </div>
+      <h2 className="text-3xl font-bold mb-3">You&rsquo;re in.</h2>
+      <p className="text-base-content/80 mb-6 max-w-md mx-auto leading-relaxed">
+        Thank you. We&rsquo;ll email you the Google Play closed-test opt-in
+        link within 24 hours. Keep an eye on the email you signed up with — if
+        you don&rsquo;t see it, check spam.
+      </p>
+      <p className="text-sm text-base-content/60 mb-8">
+        In the meantime, the web app at <Link href="/" className="link">godaisy.io</Link>{' '}
+        works on Android browsers if you want a sneak peek.
+      </p>
+      <Link href="/" className="btn btn-primary btn-lg">
+        Back to Go Daisy
+      </Link>
+    </div>
+  );
+}

--- a/pages/api/sitemap.xml.ts
+++ b/pages/api/sitemap.xml.ts
@@ -51,13 +51,48 @@ function getAppType(host: string): 'findr' | 'godaisy' | 'grow' {
 function getGoDaisyUrls(baseUrl: string): SitemapUrl[] {
   const today = new Date().toISOString().split('T')[0];
 
-  return [
+  // Static, hand-crafted pages
+  const staticUrls: SitemapUrl[] = [
+    // Homepage serves the public marketing landing page to non-authed visitors
+    // and the app to logged-in users. Highest priority.
     { loc: baseUrl, lastmod: today, changefreq: 'daily', priority: 1.0 },
-    { loc: `${baseUrl}/weather`, lastmod: today, changefreq: 'hourly', priority: 0.9 },
+
+    // Full FAQ — rich SEO surface for "does Go Daisy cover X?" queries
+    { loc: `${baseUrl}/faq`, lastmod: today, changefreq: 'weekly', priority: 0.9 },
+
+    // App pages — keep in the sitemap but ensure each has proper SEO meta
+    { loc: `${baseUrl}/weather`, lastmod: today, changefreq: 'hourly', priority: 0.8 },
     { loc: `${baseUrl}/activities`, lastmod: today, changefreq: 'daily', priority: 0.8 },
-    { loc: `${baseUrl}/settings`, lastmod: today, changefreq: 'monthly', priority: 0.3 },
-    { loc: `${baseUrl}/login`, lastmod: today, changefreq: 'monthly', priority: 0.2 },
+
+    // Android tester recruitment landing page
+    { loc: `${baseUrl}/android-testers`, lastmod: today, changefreq: 'weekly', priority: 0.6 },
+
+    // NOTE: /settings and /login deliberately omitted (have noindex meta)
   ];
+
+  // Programmatic SEO pages — one per (activity, location) combo from the
+  // curated SEO dataset. See data/seoLocations.ts.
+  // We import lazily to avoid pulling activity data into the sitemap build
+  // for the other apps (Findr, Grow Daisy) which share this sitemap endpoint.
+  let programmaticUrls: SitemapUrl[] = [];
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getAllSeoPagePaths } = require('../../data/seoLocations');
+    const slugifyActivity = (id: string) => id.replace(/_/g, '-');
+    programmaticUrls = getAllSeoPagePaths().map(
+      ({ activity, location }: { activity: string; location: string }) => ({
+        loc: `${baseUrl}/${slugifyActivity(activity)}/${location}`,
+        lastmod: today,
+        changefreq: 'daily' as const,
+        priority: 0.7,
+      })
+    );
+  } catch (err) {
+    // Programmatic SEO data not present — fine, just skip these URLs.
+    console.warn('Programmatic SEO paths unavailable for sitemap:', err);
+  }
+
+  return [...staticUrls, ...programmaticUrls];
 }
 
 /**

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,0 +1,268 @@
+/**
+ * Go Daisy — full FAQ page at /faq (lowercase URL).
+ *
+ * Replaces the role that the existing `pages/FAQs.tsx` was filling with a
+ * lowercase, indexable URL. The existing FAQs.tsx (with the surf grading
+ * deep-dive) can stay as a more specialist sub-page if you want, or its
+ * content can be folded into the surf-specific FAQs below.
+ *
+ * SEO surface:
+ *   - `<h1>` with the primary FAQ keyword
+ *   - All Q/A in plain text in the rendered HTML
+ *   - FAQPage JSON-LD for the rich-result expand/collapse arrows
+ *   - Internal links back to the landing page and across to the app
+ */
+
+import React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import AppHeader from '../components/AppHeader';
+import dynamic from 'next/dynamic';
+import SEO from '../components/SEO';
+
+const Footer = dynamic(() => import('../components/footer'), { ssr: false });
+
+// ============================================================================
+// FAQ content — grouped so the page is scannable and so JSON-LD can include
+// every question. Update text here; JSON-LD updates automatically.
+// ============================================================================
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+interface FaqGroup {
+  title: string;
+  items: FaqItem[];
+}
+
+const FAQ_GROUPS: FaqGroup[] = [
+  {
+    title: 'Getting started',
+    items: [
+      {
+        q: 'What does Go Daisy do?',
+        a: "Go Daisy is a free weather app organised around the things you want to do, not the weather itself. You tell it which activities you care about — from surfing and hiking to padel, cricket and Sunday pub afternoons — and it reads the forecast to tell you when conditions are right for each one. Less '70% chance of rain at 3pm', more 'great evening for a swim, terrible morning for the bike, classic museum afternoon.'",
+      },
+      {
+        q: 'How many activities does Go Daisy cover?',
+        a: 'Over 100, organised into six worlds: active sports (team, individual, water, action), fitness and wellness, outdoor activities (nature, fishing, kicking back), winter sports (snow and ice), creative and arts, and indoor recreation. The full list is on the home page — and you only see the ones you tell us you care about.',
+      },
+      {
+        q: 'Is Go Daisy free?',
+        a: 'Yes — completely. No paywall, no premium tier, no ads, no in-app purchases. Go Daisy is the part of what we do that is for everyone, and we mean to keep it that way.',
+      },
+      {
+        q: 'How does Go Daisy make money if it is free?',
+        a: 'It does not, directly — and that is the point. Go Daisy is free because it is how people discover what we do. We make our living from deeper specialist apps for people who go further into one thing: Findr for sea anglers, Rise Daisy for fly fishers, and Grow Daisy for serious gardeners. If you discover through Go Daisy that one of those is yours, we hope you will come along. If not, Go Daisy is yours, free, forever — no upsell screens, no premium features kept behind a wall.',
+      },
+      {
+        q: 'Do you sell my data?',
+        a: 'No. Go Daisy is independent and not ad-funded. We use your location to fetch weather for it, and we store your activity preferences so the app remembers them. See our privacy policy for full detail.',
+      },
+      {
+        q: 'Who makes Go Daisy?',
+        a: 'A small independent team based in the UK and Asturias, Spain. We also make Findr (for sea anglers), Rise Daisy (for fly fishers), and Grow Daisy (for gardeners). All four apps share the same idea: weather should be answered as a question about your life, not as a list of numbers.',
+      },
+    ],
+  },
+  {
+    title: 'Activities',
+    items: [
+      {
+        q: 'Which activities does Go Daisy cover?',
+        a: 'Currently over 100 activities across six categories: active sports (water, team, individual, action), fitness and wellness (mindfulness, cardio, strength), outdoor activities (nature, fishing, kicking back), winter sports (snow and ice), creative and arts (visual, music, literature), and indoor recreation (home, social, indoor sports).',
+      },
+      {
+        q: 'Does Go Daisy cover water sports?',
+        a: 'Yes — surfing, stand-up paddleboarding (SUP) on sea and inland, kayaking and sea kayaking, canoeing, sea swimming, wild swimming, snorkelling, sailing on sea and inland, windsurfing on sea and inland, kitesurfing, jet skiing, scuba diving and sea fishing from shore or boat. We pull wave height, swell period and direction, wind, sea temperature, tides and UV from Stormglass marine services and score each sport on its own terms — because "good for SUP" and "good for kitesurfing" are almost opposite forecasts.',
+      },
+      {
+        q: 'Does Go Daisy cover wild swimming?',
+        a: 'Yes. Wild swimming has its own score, separate from sea swimming and indoor swimming, because the things that make a wild swim safe and pleasant are different: water temperature trend, air temperature for the exit, recent rainfall (for run-off and visibility), and current weather at the spot rather than five miles away.',
+      },
+      {
+        q: 'Does Go Daisy cover football and team sports?',
+        a: 'Yes — football, rugby, cricket, hockey, netball, basketball (outdoor), beach volleyball, American football, baseball, hurling, camogie, Gaelic football and ice hockey. Outdoor team sports are scored on rainfall in the previous 24 hours and the next 6, ground conditions, wind, and visibility. Cricketers in particular get a strict answer because cricket has the strictest weather; GAA fans get proper treatment instead of being a footnote.',
+      },
+      {
+        q: 'Does Go Daisy cover padel and pickleball?',
+        a: 'Yes — and they are scored properly, not just lumped under "tennis". Padel scores account for wind on the cage and surface drying time; pickleball scores account for wind on the ball, court conditions and the hot-hour curve. Both are also covered in their indoor-court forms where the weather still matters for getting to the court but not for the game itself.',
+      },
+      {
+        q: 'Does Go Daisy cover hiking and trail running?',
+        a: 'Yes. Hiking and trail running get separate scores from road running because mountain conditions behave differently from valley conditions — we read cloud base, freezing level, wind chill at altitude, and ground saturation where the data supports it. What is comfortable in the car park can be properly nasty on the tops, and Go Daisy tries to tell you that before you set off.',
+      },
+      {
+        q: 'Does Go Daisy cover cycling?',
+        a: 'Yes — road cycling, mountain biking, gravel biking, urban cycling for getting about, and motorbike riding. We weight wind direction and gust speed heavily — a calm 15°C morning with a 30 mph crosswind is not the same ride as a calm 15°C morning without one.',
+      },
+      {
+        q: 'Does Go Daisy cover stargazing and astronomy?',
+        a: 'Yes. Stargazing gets a clear-sky score combining cloud cover, moon phase, moon illumination, twilight times (civil, nautical, astronomical) and ISS pass-overs. We do not replace star charts like Stellarium — Go Daisy answers the earlier question: is tonight even worth driving out for?',
+      },
+      {
+        q: 'Does Go Daisy cover winter sports?',
+        a: 'Yes — skiing (alpine), snowboarding, cross-country skiing, ice skating, ice hockey (outdoor and indoor), curling, and ice fishing. We read snow depth and fresh snowfall for alpine sports, wind chill at altitude, and freeze-thaw history for natural ice. Skiing and cross-country do not want the same conditions, and we score them separately.',
+      },
+      {
+        q: 'Does Go Daisy cover fishing?',
+        a: 'Yes — fly fishing on freshwater, coarse fishing, sea fishing from the shore, sea fishing from a boat, and ice fishing. Go Daisy gives you the everyday "is this a fishing day?" answer. For deeper specialist work — river gauges and hatch timing for fly fishers, tide-by-tide marks and bait windows for sea anglers — our sister apps Rise Daisy and Findr go several layers deeper than a general activity app reasonably can.',
+      },
+      {
+        q: 'Does Go Daisy cover gardening?',
+        a: 'Yes — outdoor gardening is in the everyday list, scored on soil moisture, soil temperature, frost risk, wind, rainfall and UV so you know whether today is a sowing day, a watering day, a mowing day, a frost-cloth day, or none of the above. For dedicated kitchen-garden and allotment planning with a full plant database, our sister app Grow Daisy at grow.godaisy.io is the right home for that.',
+      },
+      {
+        q: 'What about indoor activities? Does Go Daisy work when the weather is bad?',
+        a: 'Yes — and that is where it earns its keep. Go Daisy covers indoor swimming, indoor climbing, indoor tennis, squash, badminton, gym workouts, pilates, yoga, meditation, plus social and home days: pub afternoons, cinema, museums, galleries, bowling, cooking, reading, gaming, crafts, knitting, DIY, making music. When the outdoor scores are bad, the indoor and social activities you have picked get a quiet promotion — so a wet Sunday is not a wasted one.',
+      },
+      {
+        q: 'Does Go Daisy cover yoga, pilates and meditation?',
+        a: 'Yes — all three, in both indoor and outdoor versions. Outdoor yoga, outdoor meditation, and pilates and yoga as indoor practices are scored separately, because what matters for a quiet rooftop yoga session (wind, UV, air quality) does not matter for a studio class.',
+      },
+      {
+        q: 'Does Go Daisy cover photography and painting outdoors?',
+        a: 'Yes — outdoor painting (plein air) and photography both get dedicated scores. We read light quality, cloud cover, golden-hour times, wind on the easel, and the seasonal sun-angle changes that matter for both.',
+      },
+    ],
+  },
+  {
+    title: 'Coverage & technology',
+    items: [
+      {
+        q: 'Where in the world does Go Daisy work?',
+        a: 'The UK and the rest of Europe — that is where our forecast partners give us the best resolution and where we have tuned the activity scoring. The app works further afield, but UK, Ireland, France, Spain, Portugal, Italy, Germany, the Netherlands, Poland, Sweden and Turkey are the regions where we are confident the predictions are sharp.',
+      },
+      {
+        q: 'What languages does Go Daisy support?',
+        a: 'English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Turkish and Swedish.',
+      },
+      {
+        q: 'Is Go Daisy on Android?',
+        a: 'The Android version is built and in closed beta. Google Play asks new apps to put twelve testers through a fortnight of real-world use before launching to the public, and we are recruiting that group now. If you have an Android phone and would like to be one of them, see the Android testers section on the home page. The web app at godaisy.io works in any browser, on any phone, in the meantime.',
+      },
+      {
+        q: 'How is Go Daisy different from Windy, the Met Office app, or AccuWeather?',
+        a: 'The general weather apps tell you the weather and trust you to interpret it. Go Daisy tells you whether your thing is on. Windy gives you a beautiful wind map; the Met Office gives you the authoritative UK forecast; AccuWeather gives you the headline numbers. Go Daisy reads the same kinds of data — from OpenWeather, Stormglass and api.met.no — and then applies it to whichever activities you have told us you do, so you do not have to do the mental arithmetic of "is 14 mph from the south-west too much for a paddleboard at my local lake?" every time you open the app.',
+      },
+      {
+        q: 'Where does the weather data come from?',
+        a: 'OpenWeather for general forecasts, Stormglass for marine and wave data, and api.met.no (the Norwegian Meteorological Institute) for high-resolution Northern European forecasting. Tide data and astronomy come from established public ephemerides. We do not run our own weather model — we read the best public and commercial ones and turn the numbers into activity decisions.',
+      },
+      {
+        q: 'How does the surf traffic-light work?',
+        a: 'We blend the main ingredients of good surf — wave size, period, swell direction, wind, and tide — into a 0–100 score, then map it to a simple colour: green is fun, clean and safe for intermediates; amber is surfable but mixed; red is poor or unsafe for non-experts. We apply strict safety gates so conditions that are too large or powerful for intermediates are always red-flagged. If a beach orientation is unknown, we grade conservatively and note that wind impact is estimated.',
+      },
+      {
+        q: 'How often is the forecast updated?',
+        a: 'Hourly for general conditions and marine data where the underlying provider supports it. Tides and astronomy are calculated continuously. The activity scores recalculate every time you open the app, so the answer is always fresh against the latest forecast.',
+      },
+    ],
+  },
+];
+
+// ============================================================================
+// JSON-LD for FAQ rich result — built from the same content above
+// ============================================================================
+
+const allItems = FAQ_GROUPS.flatMap((g) => g.items);
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: allItems.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: f.a,
+    },
+  })),
+};
+
+// ============================================================================
+// Page
+// ============================================================================
+
+export default function FAQPage() {
+  return (
+    <>
+      <SEO
+        title="Frequently asked questions"
+        description="Everything about Go Daisy — what activities we cover (surf, hiking, padel, cricket, stargazing, fishing, gardening and 100+ more), where the data comes from, and how the scoring works. Free, ad-free, UK and Europe."
+        url="https://godaisy.io/faq"
+      />
+
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+      </Head>
+
+      <AppHeader />
+
+      <main className="min-h-screen bg-base-100 text-base-content">
+        <section className="px-4 py-12 md:py-20 bg-gradient-to-b from-base-200 to-base-100">
+          <div className="max-w-3xl mx-auto text-center">
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">
+              Go Daisy — frequently asked questions
+            </h1>
+            <p className="text-lg text-base-content/80">
+              The full answers — to which activities Go Daisy covers, where
+              the data comes from, and what makes a good day for each thing.
+            </p>
+          </div>
+        </section>
+
+        <section className="px-4 py-12">
+          <div className="max-w-3xl mx-auto space-y-12">
+            {FAQ_GROUPS.map((group) => (
+              <div key={group.title}>
+                <h2 className="text-2xl md:text-3xl font-bold mb-6">
+                  {group.title}
+                </h2>
+                <div className="join join-vertical w-full">
+                  {group.items.map((item) => (
+                    <div
+                      key={item.q}
+                      className="collapse collapse-arrow join-item border border-base-300 bg-base-100"
+                    >
+                      <input type="checkbox" aria-label={item.q} />
+                      <h3 className="collapse-title text-lg font-medium">
+                        {item.q}
+                      </h3>
+                      <div className="collapse-content">
+                        <p>{item.a}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="px-4 py-16 bg-base-200">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-2xl md:text-3xl font-bold mb-4">
+              Still curious?
+            </h2>
+            <p className="text-base-content/80 mb-6">
+              Open Go Daisy and pick the activities you care about. The
+              answers it gives you for the next seven days will tell you more
+              than any FAQ can.
+            </p>
+            <Link href="/" className="btn btn-primary btn-lg">
+              Try the web app — free
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,6 +23,7 @@ import Link from 'next/link';
 import type { MarineHour } from '../types/weatherTypes';
 import { useUIText } from '../hooks/useUIText';
 import SEO from '../components/SEO';
+import LandingPage from '../components/LandingPage';
 type LocationLite = { name: string; lat: number; lon: number; type?: 'home'|'coastal' };
 
 import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
@@ -58,7 +59,7 @@ const AstronomyCard = dynamic(() => import('../components/AstronomyCard'), {
 });
 
 export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { query } = ctx;
+  const { query, req, res } = ctx;
   const code = typeof query.code === 'string' ? query.code : undefined;
   const type = typeof query.type === 'string' ? query.type : undefined;
 
@@ -76,7 +77,32 @@ export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSideP
     };
   }
 
-  return { props: {} };
+  // ----- Landing page decision -----
+  // Show the public marketing landing page when ALL of these are true:
+  //   1. the visitor is NOT inside the Capacitor (native iOS/Android) shell
+  //   2. the visitor is NOT logged in (no Supabase session cookie)
+  //
+  // If Capacitor's user-agent uses a different identifier in production,
+  // add it to the regex below.
+  const userAgent = (req.headers['user-agent'] || '').toString();
+  const isCapacitor = /Capacitor|wotnow-app|godaisy-app/i.test(userAgent);
+
+  // Supabase auth session cookies are named `sb-<project-ref>-auth-token`.
+  // Presence check is good enough for the SSR landing-vs-app decision;
+  // actual auth validation still happens client-side in the app code.
+  const cookieHeader = (req.headers.cookie || '').toString();
+  const hasSupabaseSession = /sb-[^=]+-auth-token=/i.test(cookieHeader);
+
+  const showLanding = !isCapacitor && !hasSupabaseSession;
+
+  // Cache headers: landing is the same for everyone (cacheable); app is per-user.
+  if (showLanding) {
+    res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400');
+  } else {
+    res.setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+  }
+
+  return { props: { showLanding } };
 };
 
 // Simple JSON fetch with retry/backoff for flaky endpoints
@@ -465,7 +491,7 @@ const _getTargetHourForDay = (dayUnixTimestamp: number): string => {
   return `${dayDate.toISOString().slice(0, 10)}T${hour.toString().padStart(2, '0')}`;
 };
 
-export default function Home() {
+function HomeApp() {
   // Fish species modal state (for hero/favourites)
   const [popupActivity, setPopupActivity] = useState<ReturnType<typeof buildPopupActivityPayload> | null>(null);
   const [shareActivity, setShareActivity] = useState<{ id: string; name: string; emoji: string } | null>(null);
@@ -1289,4 +1315,20 @@ function getWeatherDay(day: WeatherForecastDay) {
     clouds: day.clouds,
     // Add more OpenWeather fields as needed
   };
+}
+
+/**
+ * Top-level page entry point.
+ *
+ * Picks between the public marketing landing page and the logged-in app
+ * dashboard based on the `showLanding` flag set in getServerSideProps.
+ *
+ * - showLanding = true:  unauthenticated web visitors (and Googlebot)
+ *                        get the marketing landing page
+ * - showLanding = false: Capacitor app users and logged-in users get
+ *                        the existing app dashboard (HomeApp)
+ */
+export default function HomePage({ showLanding }: { showLanding: boolean }) {
+  if (showLanding) return <LandingPage />;
+  return <HomeApp />;
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -303,6 +303,8 @@ export default function GoDaisyLogin() {
     <>
       <Head>
         <title>Sign In - {appName}</title>
+        {/* Login is a private app surface; keep it out of search results. */}
+        <meta name="robots" content="noindex,nofollow" />
       </Head>
       <div
         className={`min-h-screen flex items-center justify-center p-4 safe-area-bottom ${

--- a/pages/weather.tsx
+++ b/pages/weather.tsx
@@ -481,14 +481,19 @@ export default function WeatherPage() {
   return (
     <>
       <SEO
-        title="Weather Dashboard"
-        description="Detailed weather forecasts with marine conditions, tides, air quality, and astronomy data. Plan your outdoor activities with confidence."
+        title="Hourly weather, marine, tides, astronomy and air quality"
+        description="Full weather dashboard for outdoor activities — hourly forecasts, wave height and swell, tide times, sunrise/sunset, moon phase, ISS passes, UV, pollen and air quality. Free, ad-free, UK and Europe."
         url="https://godaisy.io/weather"
       />
       <div
         className="relative min-h-screen"
         data-testid="page-new-weather"
       >
+        {/* Screen-reader-accessible H1 so the page has a proper heading for
+            search engines without disrupting the visual dashboard layout. */}
+        <h1 className="sr-only">
+          Go Daisy — hourly weather, marine, tides and astronomy dashboard
+        </h1>
         <div className="relative z-20">
           <AppHeader
           homeLocation={homeLocation || undefined}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,58 +1,101 @@
-# Grow Daisy — Smart Garden Planner for UK & Irish Gardeners
-> UK garden planner with RHS hardiness ratings, postcode-aware frost dates, weather-driven tasks for allotments, veg patches, and kitchen gardens. Multilingual plant database covering 50,000+ species.
+# Go Daisy — Free weather app for 100+ activities
+> Smart weather recommendations across 100+ outdoor and indoor activities. Reads wind, waves, tides, UV, pressure, snow, soil moisture and sky to score each activity hour by hour for the UK and Europe. Free, ad-free, available on iOS and the web. Android in closed beta.
+
+## What Go Daisy is
+
+Go Daisy is a free weather app organised around the things you want to do, not the weather itself. Users tell Go Daisy which activities they care about — from surfing and hiking to padel, cricket, stargazing, gardening and pub afternoons — and Go Daisy reads the forecast to tell them when conditions are right for each one. The app is built by independent makers in the UK and Asturias, Spain, and is supported by deeper specialist sister apps (Findr, Rise Daisy, Grow Daisy) rather than by ads.
 
 ## Core pages
-- [Home](https://grow.godaisy.io/grow): Smart garden planner overview
-- [Plan](https://grow.godaisy.io/grow/plan): Weekly planting calendar and task planner
-- [Garden](https://grow.godaisy.io/grow/garden): Track your plants and growing spaces
-- [Activities](https://grow.godaisy.io/grow/activities): What to do in the garden this week
-- [Weather](https://grow.godaisy.io/grow/weather): Garden-relevant weather forecasts
-- [Tasks](https://grow.godaisy.io/grow/tasks): Seasonal task reminders and care calendar
-- [Settings](https://grow.godaisy.io/grow/settings): Location, climate zone, and preference settings
+- [Home](https://godaisy.io): Free weather app for 100+ activities — landing, signup
+- [FAQ](https://godaisy.io/faq): Full answers about coverage, scoring, data sources
+- [Weather](https://godaisy.io/weather): Hourly weather dashboard with marine, tides, air quality and astronomy
+- [Activities](https://godaisy.io/activities): User's chosen activities scored for the next seven days
+- [About us](https://godaisy.io/AboutUs): Who builds Go Daisy
+- [How we do it](https://godaisy.io/HowWeDoIt): The data sources and scoring approach
+- [Android testers](https://godaisy.io/android-testers): Sign up to help launch on Google Play
 
-## Plant database
-Plant pages cover 50,000+ species with growing advice, planting calendars, companion planting, and pest/disease guidance. Each page is available at /grow/species/[slug] — see the sitemap at https://grow.godaisy.io/sitemap.xml for the complete list.
+## Activities Go Daisy scores
 
-A selection of popular UK kitchen garden plants:
-- [Tomato](https://grow.godaisy.io/grow/species/tomato): Growing tomatoes in the UK
-- [Potato](https://grow.godaisy.io/grow/species/potato): Growing potatoes in the UK
-- [Carrot](https://grow.godaisy.io/grow/species/carrot): Growing carrots in the UK
-- [Courgette](https://grow.godaisy.io/grow/species/courgette): Growing courgettes in the UK
-- [Runner bean](https://grow.godaisy.io/grow/species/runner-bean): Growing runner beans in the UK
-- [French bean](https://grow.godaisy.io/grow/species/french-bean): Growing French beans in the UK
-- [Broad bean](https://grow.godaisy.io/grow/species/broad-bean): Growing broad beans in the UK
-- [Pea](https://grow.godaisy.io/grow/species/pea): Growing peas in the UK
-- [Lettuce](https://grow.godaisy.io/grow/species/lettuce): Growing lettuce in the UK
-- [Spinach](https://grow.godaisy.io/grow/species/spinach): Growing spinach in the UK
-- [Kale](https://grow.godaisy.io/grow/species/kale): Growing kale in the UK
-- [Cabbage](https://grow.godaisy.io/grow/species/cabbage): Growing cabbage in the UK
-- [Broccoli](https://grow.godaisy.io/grow/species/broccoli): Growing broccoli in the UK
-- [Cauliflower](https://grow.godaisy.io/grow/species/cauliflower): Growing cauliflower in the UK
-- [Onion](https://grow.godaisy.io/grow/species/onion): Growing onions in the UK
-- [Garlic](https://grow.godaisy.io/grow/species/garlic): Growing garlic in the UK
-- [Leek](https://grow.godaisy.io/grow/species/leek): Growing leeks in the UK
-- [Beetroot](https://grow.godaisy.io/grow/species/beetroot): Growing beetroot in the UK
-- [Parsnip](https://grow.godaisy.io/grow/species/parsnip): Growing parsnips in the UK
-- [Swede](https://grow.godaisy.io/grow/species/swede): Growing swede in the UK
-- [Turnip](https://grow.godaisy.io/grow/species/turnip): Growing turnips in the UK
-- [Cucumber](https://grow.godaisy.io/grow/species/cucumber): Growing cucumbers in the UK
-- [Pumpkin](https://grow.godaisy.io/grow/species/pumpkin): Growing pumpkins in the UK
-- [Squash](https://grow.godaisy.io/grow/species/squash): Growing squash in the UK
-- [Aubergine](https://grow.godaisy.io/grow/species/aubergine): Growing aubergines in the UK
-- [Pepper](https://grow.godaisy.io/grow/species/pepper): Growing peppers in the UK
-- [Chilli](https://grow.godaisy.io/grow/species/chilli): Growing chillies in the UK
-- [Strawberry](https://grow.godaisy.io/grow/species/strawberry): Growing strawberries in the UK
-- [Raspberry](https://grow.godaisy.io/grow/species/raspberry): Growing raspberries in the UK
-- [Blackcurrant](https://grow.godaisy.io/grow/species/blackcurrant): Growing blackcurrants in the UK
-- [Gooseberry](https://grow.godaisy.io/grow/species/gooseberry): Growing gooseberries in the UK
-- [Apple](https://grow.godaisy.io/grow/species/apple): Growing apple trees in the UK
-- [Pear](https://grow.godaisy.io/grow/species/pear): Growing pear trees in the UK
-- [Plum](https://grow.godaisy.io/grow/species/plum): Growing plum trees in the UK
-- [Lavender](https://grow.godaisy.io/grow/species/lavender): Growing lavender in the UK
-- [Rose](https://grow.godaisy.io/grow/species/rose): Growing roses in the UK
-- [Sweet pea](https://grow.godaisy.io/grow/species/sweet-pea): Growing sweet peas in the UK
-- [Sunflower](https://grow.godaisy.io/grow/species/sunflower): Growing sunflowers in the UK
-- [Marigold](https://grow.godaisy.io/grow/species/marigold): Growing marigolds in the UK
+Over 100 activities across six categories. Each activity is scored on the hourly conditions that actually matter for it — water sports get wave height, swell period and tide; team sports get rainfall in the previous 24 hours and the next 6; astronomy gets cloud cover and moon phase; gardening gets soil temperature and moisture.
+
+### Active sports
+
+**Team sports:** football, cricket, rugby, basketball (outdoor), beach volleyball, American football, baseball, hurling, camogie, Gaelic football, hockey, netball, ice hockey.
+
+**Individual sports:** golf, tennis, indoor tennis, squash, badminton, table tennis, archery, pickleball, indoor volleyball, padel.
+
+**Water sports:** surfing, stand-up paddleboarding (SUP) on sea and inland, kayaking, sea kayaking, canoeing, sea swimming, indoor swimming, snorkelling, scuba diving, sailing on sea and inland, windsurfing on sea and inland, kitesurfing, jet skiing, sea fishing from shore, sea fishing from boat.
+
+**Action sports:** mountain biking, road cycling, gravel biking, rock climbing, rock hopping, indoor climbing, skateboarding, rollerblading, motorbike riding.
+
+### Fitness & wellness
+
+**Mindfulness:** yoga, outdoor yoga, meditation, outdoor meditation, pilates, martial arts, tai chi.
+
+**Cardio & running:** running, trail running, cycling, urban exploring.
+
+**Strength & gym:** gym workouts, outdoor gyms, Zumba, boxing, spinning.
+
+### Outdoor activities
+
+**Nature:** hiking, birdwatching, photography, foraging, mushroom hunting, wild swimming, outdoor gardening, stargazing.
+
+**Fishing:** fly fishing on freshwater, coarse fishing, sea fishing from shore, sea fishing from boat, ice fishing.
+
+**Kicking back & relaxing:** picnicking, barbecues, beach days, camping, gaming, reading, going to the pub, outdoor reading, dog walking, outdoor playground, outdoor chess, outdoor painting, outdoor music.
+
+### Winter sports
+
+**Snow sports:** skiing (alpine), snowboarding, cross-country skiing.
+
+**Ice sports:** ice skating, curling, ice hockey, ice fishing, indoor ice hockey.
+
+### Creative & arts
+
+**Visual arts:** painting, outdoor painting (plein air), crafts, photography, knitting, DIY.
+
+**Music & performance:** playing records, making music, dance, outdoor music.
+
+**Literature & learning:** reading, outdoor reading.
+
+### Indoor recreation
+
+**Home activities:** crafts, knitting, reading, DIY, playing records, cooking, painting, gaming, online time.
+
+**Social activities:** going to the pub, table tennis, playing cards, watching a film, café days, cinema, museum, shopping, dance, gallery, bowling.
+
+**Indoor sports:** indoor climbing, squash, badminton, indoor tennis, indoor swimming, gym workouts, pilates, yoga, meditation.
+
+## Data sources
+
+Go Daisy reads professional-grade forecasts and applies activity-specific scoring.
+
+- **General weather forecasts:** OpenWeather
+- **Marine and wave data:** Stormglass
+- **High-resolution Northern European forecasting:** api.met.no (Norwegian Meteorological Institute)
+- **Tide data:** Stormglass Tides API
+- **Astronomy:** standard ephemerides for sun, moon, twilight times, ISS pass-overs
+
+## Coverage and languages
+
+**Geography:** UK and Europe primarily. Tuned for UK, Ireland, France, Spain, Portugal, Italy, Germany, the Netherlands, Poland, Sweden and Turkey.
+
+**Languages:** English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Turkish, Swedish.
+
+**Platforms:** iOS (iPhone, iPad, Mac with Apple Silicon, Apple Vision), web (godaisy.io). Android in closed beta.
+
+## Pricing
+
+Go Daisy is free, forever. No paywall, no premium tier, no ads, no in-app purchases. The product is supported by deeper specialist sister apps (Findr for sea anglers, Rise Daisy for fly fishers, Grow Daisy for serious gardeners) rather than by user payments or ads.
+
+## Sister apps in the Daisy family
+
+- **Findr** — for sea anglers. Tide-by-tide marks, bait windows, deep marine forecasting. fishfindr.eu
+- **Rise Daisy** — for fly fishers. River gauges, hatch prediction, water temperature, scoring for trout, salmon, grayling, sea trout.
+- **Grow Daisy** — for serious gardeners and allotment holders. RHS plant database, sowing calendars, companion planting, pest watch. grow.godaisy.io
+
+All four apps share the same idea: weather is best answered as a question about your life, not as a list of numbers.
 
 ## About
-Grow Daisy is part of the Daisy family — weather-informed apps for outdoor enthusiasts. Web app at https://grow.godaisy.io, iOS app on the App Store.
+
+Go Daisy is built by independent makers in the UK and Asturias, Spain. Web app at https://godaisy.io. iOS app on the Apple App Store at https://apps.apple.com/gb/app/go-daisy/id6755695873.

--- a/supabase/migrations/20260514016_android_testers.sql
+++ b/supabase/migrations/20260514016_android_testers.sql
@@ -1,0 +1,108 @@
+-- ============================================================================
+-- Migration: android_testers signup table
+-- ============================================================================
+-- Creates a table to capture people who sign up via /android-testers to help
+-- launch Go Daisy on Google Play (Google requires 12 testers for a fortnight
+-- before a new app can be released to production).
+--
+-- Security model:
+--   - RLS enabled
+--   - Anonymous users can INSERT (so the public signup form works)
+--   - Anonymous users CANNOT SELECT (so the list can't be enumerated from the
+--     browser even if someone inspects the network tab)
+--   - Service role / authenticated admin users have full access (default)
+--
+-- View signups via the Supabase dashboard or with the service role key.
+-- ============================================================================
+
+create table if not exists public.android_testers (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  name text,
+  country text,
+  primary_activity text,
+  created_at timestamptz not null default now(),
+  -- status tracks the tester's journey:
+  --   'signed_up' (initial), 'invited' (added to Play Console),
+  --   'opted_in' (clicked the link), 'completed' (finished 14-day test)
+  status text not null default 'signed_up',
+  -- free-text notes for the admin
+  notes text,
+  -- unique on lower(email) to dedupe case-insensitively
+  constraint android_testers_email_unique unique (email)
+);
+
+-- Helpful index for the admin "who's outstanding?" query
+create index if not exists android_testers_status_idx
+  on public.android_testers (status, created_at desc);
+
+-- Lowercase email automatically so duplicates are caught regardless of case
+create or replace function public.android_testers_normalize_email()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.email := lower(trim(new.email));
+  return new;
+end;
+$$;
+
+drop trigger if exists android_testers_normalize_email_trigger
+  on public.android_testers;
+
+create trigger android_testers_normalize_email_trigger
+  before insert or update on public.android_testers
+  for each row execute function public.android_testers_normalize_email();
+
+-- ============================================================================
+-- Row Level Security
+-- ============================================================================
+
+alter table public.android_testers enable row level security;
+
+-- Allow anonymous (anon) users to insert new signups via the public form.
+-- Deliberately does NOT include a USING clause so anon cannot read existing
+-- rows back; the INSERT just doesn't return the inserted row to the client.
+drop policy if exists "anon can insert signups" on public.android_testers;
+create policy "anon can insert signups"
+  on public.android_testers
+  for insert
+  to anon
+  with check (true);
+
+-- Authenticated admin / service role gets full access by default (no policy
+-- needed for service role — it bypasses RLS).
+-- If you want signed-in app users to read their own signup (e.g. so a logged-
+-- in user can see whether they already opted in), uncomment the policy below.
+
+-- drop policy if exists "authenticated can read own signup" on public.android_testers;
+-- create policy "authenticated can read own signup"
+--   on public.android_testers
+--   for select
+--   to authenticated
+--   using (lower(email) = lower((auth.jwt() ->> 'email')::text));
+
+-- ============================================================================
+-- Helpful admin views (optional)
+-- ============================================================================
+
+create or replace view public.android_testers_summary as
+select
+  status,
+  count(*) as tester_count,
+  min(created_at) as earliest,
+  max(created_at) as latest
+from public.android_testers
+group by status
+order by status;
+
+-- Restrict the summary view to authenticated admins
+revoke all on public.android_testers_summary from anon;
+grant select on public.android_testers_summary to authenticated;
+
+-- ============================================================================
+-- Done
+-- ============================================================================
+comment on table public.android_testers is
+  'Public signup list for the Go Daisy Android closed-beta testing programme. '
+  'Inserted via /android-testers form; read only via admin / service role.';


### PR DESCRIPTION
## Summary

- **New homepage**: replaces the skeleton-loader with a proper marketing `LandingPage` component (hero, activity cards, social proof, CTA) — logged-in users and Capacitor still see the app dashboard
- **Programmatic SEO route**: `pages/[activity]/[location].tsx` with ISR (`revalidate: 3600`, `fallback: 'blocking'`) — ships ~100 indexable URLs from 10 seed locations × 10 activities; `data/seoLocations.ts` has `coastalEuropean()` / `alpineCity()` helpers ready to scale to thousands
- **Score helper**: `lib/seo/getActivityScore.ts` wraps the existing `getSuggestionsByDay` engine so programmatic pages use identical scoring to the app
- **Sitemap + LLMs.txt**: expanded to include programmatic routes, FAQ, and corrected Go Daisy descriptions (was stale Grow copy)
- **New static pages**: `/faq` and `/android-testers`
- **Migration**: `20260514016_android_testers.sql` — needs `supabase db push` after merge

## Post-merge checklist

- [ ] Run `supabase db push` (or paste migration SQL into dashboard) to apply android_testers table
- [ ] Google Search Console → Request Indexing on `/` and one programmatic page (e.g. `/hiking/cornwall`)
- [ ] Rich Results Test on `/` (FAQPage JSON-LD) and a programmatic page
- [ ] Expand `data/seoLocations.ts` with more seeds to grow from ~100 → thousands of programmatic URLs

## Test plan

- [ ] `npm run build` passes (lint + typecheck clean)
- [ ] `/` shows LandingPage for unauthenticated web visitors, app for logged-in users
- [ ] `/hiking/cornwall` (or any valid activity/location slug) renders without 404
- [ ] `/faq` and `/android-testers` render
- [ ] `/sitemap.xml` includes programmatic URLs
- [ ] Invalid slugs return 404 (not found in `seoLocations.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)